### PR TITLE
Only update gmt_hash_server.txt if it chagned

### DIFF
--- a/update_file_hash.sh
+++ b/update_file_hash.sh
@@ -27,7 +27,12 @@ while read path; do
 done < /tmp/$$.lis
 rm -f /tmp/$$.lis
 
-# 3. Overwrite old file with new hash table
+# 3. Overwrite old file with new hash table if it changed
 
-mv -f $DATA/gmt_hash_server.txt $DATA/gmt_hash_server_previous.txt
-mv -f $DATA/next_gmt_hash_server.txt $DATA/gmt_hash_server.txt
+update=`diff -q $DATA/gmt_hash_server.txt $DATA/gmt_hash_server_previous.txt`
+if [ "X${update}" == "X" ]; then	# No change
+	rm -f $DATA/next_gmt_hash_server.txt
+else					# Keep previous and update current
+	mv -f $DATA/gmt_hash_server.txt $DATA/gmt_hash_server_previous.txt
+	mv -f $DATA/next_gmt_hash_server.txt $DATA/gmt_hash_server.txt
+fi


### PR DESCRIPTION
Because any change to the repo, such as to the helper scripts, trigger the update_hash function, we add a test to determine if the hash table changed.  Only then do we update the current table.