### PR TITLE
Ignore files produced in the staging directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 .DS_Store
 **/gmt.history
 .*~
-staging/*.grd
-staging/*.nc
-staging/*.sh
-staging/*.pdf
-staging/*.jpg
-staging/*.png
-staging/*.txt
+staging/*
+!staging/README.md


### PR DESCRIPTION
Not happy with this yet.  I want the staging dir and its README.md to be part of the github-controlled files, but not any files we may produce in there.  Is that possible? I looked for regex that would only allow README.md but no luck.  So I added a few likely candidates of filetypes.  Please improve.