### PR TITLE
Duplicate cache and MD5 file so rsync can work

### DIFF
--- a/scripts/srv_git_update.sh
+++ b/scripts/srv_git_update.sh
@@ -17,6 +17,10 @@ count=`git rev-list master ^origin/master --count`
 if [ "$count" -ne "0" ]; then	# 5. There will be updates
 	# 5a Update the local repo
 	git pull origin master
-	# 5b Update the SHA256 hash table
+	# 5b Do rsync of files than may have changed to data/cache
+	rsync -a cache ../data
+	# 5c Update the SHA256 hash table
 	bash scripts/srv_update_sha256.sh
+	# 5d Duplicate to the Md5 file for backwardness
+	cp -f ../data/gmt_hash_server.txt ../data/gmt_md5_server.txt
 fi

--- a/scripts/srv_git_update.sh
+++ b/scripts/srv_git_update.sh
@@ -18,7 +18,7 @@ if [ "$count" -ne "0" ]; then	# 5. There will be updates
 	# 5a Update the local repo
 	git pull origin master
 	# 5b Do rsync of files than may have changed to data/cache
-	rsync -a cache ../data
+	rsync -a --delete cache ../data
 	# 5c Update the SHA256 hash table
 	bash scripts/srv_update_sha256.sh
 	# 5d Duplicate to the Md5 file for backwardness


### PR DESCRIPTION
Once this script is deemed correct, I will delete the two symlinks on the server and this script will rsync and cp the files needed.  Please check that my rsync command is correct.  The srv_git_update.sh script does a cd into gmtserver-admin and that directory is at the same level as the data directory under which we have the earth_relief* files, the cache directory, and the hash tables.
After upload and activation of this PR there should no longer be any symbolic links.  The duplication of the cache dir is only ~80 Mb.