### PR TITLE
Get desired chunk-size from recipe file

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,6 +1,6 @@
 # Grid Downsampling Recipes
 
-This directory contains recipe files that specifies which original data
+This directory contains recipe files that specify which original data
 set needs to be downsampled and what output resolutions are requested.
 We must specify the planetary radius (in km) and desired output format
 and registration.

--- a/recipes/earth_relief.recipe
+++ b/recipes/earth_relief.recipe
@@ -19,18 +19,18 @@
 # DST_TILE_TAG=ER
 # DST_TILE_SIZE=1200
 #
-# List of desired output resolution.  Flag the source resolution with code == master
-# resolution	unit	code
-15	s	master
-30	s	
-01	m
-02	m
-03	m
-04	m
-05	m
-06	m
-10	m
-15	m
-20	m
-30	m
-01	d
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	chunk	code
+15	s	4096	master
+30	s	4096
+01	m	4096
+02	m	4096
+03	m	2048
+04	m	2048
+05	m	2048
+06	m	4096
+10	m	4096
+15	m	4096
+20	m	4096
+30	m	4096
+01	d	4096

--- a/scripts/srv_downsampler.sh
+++ b/scripts/srv_downsampler.sh
@@ -83,7 +83,7 @@ else
 fi
 
 # 9. Loop over all the resolutions found
-while read RES UNIT MASTER; do
+while read RES UNIT CHUNK MASTER; do
 	if [ "X$UNIT" = "Xd" ]; then	# Gave increment in degrees
 		INC=$RES
 		UNIT_NAME=degree
@@ -115,7 +115,7 @@ while read RES UNIT MASTER; do
 		# Get suitable Gaussian full-width filter rounded to nearest 0.1 km
 		echo "Down-filter ${SRC_FILE} to ${DST_FILE}=${DST_FORMAT}"
 		FILTER_WIDTH=`gmt math -Q ${SRC_RADIUS} 2 MUL PI MUL 360 DIV $INC MUL 10 MUL RINT 10 DIV =`
-		gmt grdfilter ${SRC_FILE} -Fg${FILTER_WIDTH} -D${FMODE} -I${RES}${UNIT} -r${DST_NODES} -G${DST_FILE}=${DST_FORMAT} --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=4096 --PROJ_ELLIPSOID=Sphere
+		gmt grdfilter ${SRC_FILE} -Fg${FILTER_WIDTH} -D${FMODE} -I${RES}${UNIT} -r${DST_NODES} -G${DST_FILE}=${DST_FORMAT} --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=${CHUNK} --PROJ_ELLIPSOID=Sphere
 		remark="Obtained by Gaussian ${DST_MODE} filtering (${FILTER_WIDTH} km fullwidth) from ${SRC_FILE/+/\\+} [${REMARK}]"
 		gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
 	fi


### PR DESCRIPTION
We are pushing the chunk sizes up to get smaller files to download.  However, this ran into a crash for some combinations of resolution.  This PR adds the desired **chunk size** to the recipe so that we can fine-tune what works.  The reduced size worked for 03.  If 04 and 05 requires different chunks then I will experiment until it works.