### PR TITLE
Add recipe for processing seafloor age grids

### DIFF
--- a/recipes/earth_age.recipe
+++ b/recipes/earth_age.recipe
@@ -1,4 +1,4 @@
-# Recipe file for down-filtering seafloor gges grid
+# Recipe file for down-filtering seafloor ages grid
 #
 # To be given as input file to script srv_downsampler.sh
 #

--- a/recipes/earth_age.recipe
+++ b/recipes/earth_age.recipe
@@ -1,0 +1,34 @@
+# Recipe file for down-filtering seafloor gges grid
+#
+# To be given as input file to script srv_downsampler.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=https://earthbyte.org/webdav/ftp/earthbyte/agegrid/2020/Grids/age.2020.1.GTS2012.1m.nc
+# SRC_TITLE=Earth_Seafloor_Age
+# SRC_REMARK="Seton_et_al.,_2020;_in_prep"
+# SRC_RADIUS=6371.0087714
+# SRC_NAME=ages
+# SRC_UNIT=My
+#
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g
+# DST_PREFIX=earth_age
+# DST_FORMAT=ns+sa
+# DST_TILE_TAG=ER
+# DST_TILE_SIZE=1200
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	chunk	code
+01	m	4096	master
+02	m	4096
+03	m	2048
+04	m	2048
+05	m	2048
+06	m	4096
+10	m	4096
+15	m	4096
+20	m	4096
+30	m	4096
+01	d	4096

--- a/scripts/srv_downsampler.sh
+++ b/scripts/srv_downsampler.sh
@@ -60,12 +60,12 @@ SRC_ORIG=${SRC_BASENAME}
 is_url=`echo ${SRC_FILE} | grep -c :`
 if [ $is_url ]; then	# Data source is an URL
 	if [ ! -f ${SRC_BASENAME} ]; then # Must download first
-		curl ${SRC_FILE} --output ${SRC_BASENAME}
+		curl -k ${SRC_FILE} --output ${SRC_BASENAME}
 	fi
 	SRC_ORIG=${SRC_FILE}
 	SRC_FILE=${SRC_BASENAME}
 fi
-	 
+
 # 6. Extract the requested resolutions
 grep -v '^#' $RECIPE > /tmp/res.lis
 # 7. Replace underscores with spaces in the title and remark


### PR DESCRIPTION
I've been in conversation with EarthByte (Dietmar Müller and Maria Seton) about us distributing the latest **age grid** via remote files.  They are about to publish a 2020 version and they have made a 1 arc minute version just for me.  This PR adds a recipe file for how to build the different resolutions.  I (re)discovered the handy **+s**a option for auto-scaling a grid to fit the given bits.  The latest age grid has a max value of 338.68 Myr so they could no longer use 0.01 scale and thus just made a float grid at 206 Mb.  But with =ns+sa I automatically get a scale factor of 0.05... because it also sets an offset and stretches to the whole -32767/+32767 range so this has even higher precision than the old 0.01 My and takes up only 59 Mb.  The downsampled ones are smaller still.  I will be making some maps and test things to compare to the 2m and 6 m version they make, and perhaps they can be persuaded to drop those if ours work well.