### PR TITLE
Optionally create both pixel and gridline versions during downsamling

### DIFF
--- a/recipes/earth_age.recipe
+++ b/recipes/earth_age.recipe
@@ -13,7 +13,7 @@
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
-# DST_NODES=g
+# DST_NODES=g,p
 # DST_PREFIX=earth_age
 # DST_FORMAT=ns+sa
 # DST_TILE_TAG=ER

--- a/recipes/earth_relief.recipe
+++ b/recipes/earth_relief.recipe
@@ -13,7 +13,7 @@
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
-# DST_NODES=g
+# DST_NODES=g,p
 # DST_PREFIX=earth_relief
 # DST_FORMAT=ns
 # DST_TILE_TAG=ER

--- a/scripts/srv_downsampler.sh
+++ b/scripts/srv_downsampler.sh
@@ -3,7 +3,7 @@
 #
 # usage: srv_downsampler.sh recipe.
 # where
-#	recipe:		The name of the recipe file (e.g., earth_relief.recipe)
+#	recipe:		The name of the recipe file (e.g., earth_relief)
 #
 # These recipe files contain meta data such as where to get the highest-resolution
 # master file from which to derive the lower-resolution versions, information about
@@ -34,7 +34,7 @@ fi
 cd ${TOPDIR}/staging
 	
 # 2. Get recipe full file path
-RECIPE=$TOPDIR/recipes/$1
+RECIPE=$TOPDIR/recipes/$1.recipe
 if [ ! -f $RECIPE ]; then
 	echo "error: srv_downsampler.sh: Recipe $RECIPE not found"
 	exit -1
@@ -56,6 +56,7 @@ source /tmp/par.sh
 # 4. Get the file name of the source file
 SRC_BASENAME=`basename ${SRC_FILE}`
 SRC_ORIG=${SRC_BASENAME}
+
 # 5. Determine if this source is an URL and if we need to download it first
 is_url=`echo ${SRC_FILE} | grep -c :`
 if [ $is_url ]; then	# Data source is an URL
@@ -66,8 +67,17 @@ if [ $is_url ]; then	# Data source is an URL
 	SRC_FILE=${SRC_BASENAME}
 fi
 
-# 6. Extract the requested resolutions
+# 6. Extract the requested resolutions and registrations
+
 grep -v '^#' $RECIPE > /tmp/res.lis
+DST_NODES=$(echo $DST_NODES | tr ',' ' ')
+REG=$(gmt grdinfo ${SRC_FILE} -Cn -o10)
+if [ $REG -eq 0 ]; then
+	SRC_REG=g
+else
+	SRC_REG=p
+fi
+
 # 7. Replace underscores with spaces in the title and remark
 TITLE=`echo ${SRC_TITLE} | tr '_' ' '`
 REMARK=`echo ${SRC_REMARK} | tr '_' ' '`
@@ -100,25 +110,28 @@ while read RES UNIT CHUNK MASTER; do
 	if [ ! ${RES} = "01" ]; then	# Use plural unit
 		UNIT_NAME="${UNIT_NAME}s"
 	fi
-	DST_FILE=${DST_PREFIX}_${RES}${UNIT}.grd
-	grdtitle="${TITLE} at ${RES} arc ${UNIT_NAME}"
-	# Note: The ${SRC_ORIG/+/\\+} below is to escape any plus-symbols in the file name with a backslash so grdedit -D will work
-	if [ -f ${DST_FILE} ]; then	# Do nothing
-		echo "${DST_FILE} exist - skipping"
-	elif [ "X${MASTER}" = "Xmaster" ]; then # Just make a copy of the master
-		echo "Convert ${SRC_FILE} to ${DST_FILE}=${DST_FORMAT}"
-		gmt grdconvert ${SRC_FILE} ${DST_FILE}=${DST_FORMAT} --IO_NC4_DEFLATION_LEVEL=9
-		remark="Reformatted from master file ${SRC_ORIG/+/\\+} [${REMARK}]"
-		gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
-
-	else	# Must downsample to a lower resolution via spherical Gaussian filtering
-		# Get suitable Gaussian full-width filter rounded to nearest 0.1 km after adding 50 meters for noise
-		echo "Down-filter ${SRC_FILE} to ${DST_FILE}=${DST_FORMAT}"
-		FILTER_WIDTH=`gmt math -Q ${SRC_RADIUS} 2 MUL PI MUL 360 DIV $INC MUL 0.05 ADD 10 MUL RINT 10 DIV =`
-		gmt grdfilter ${SRC_FILE} -Fg${FILTER_WIDTH} -D${FMODE} -I${RES}${UNIT} -r${DST_NODES} -G${DST_FILE}=${DST_FORMAT} --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=${CHUNK} --PROJ_ELLIPSOID=Sphere
-		remark="Obtained by Gaussian ${DST_MODE} filtering (${FILTER_WIDTH} km fullwidth) from ${SRC_FILE/+/\\+} [${REMARK}]"
-		gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
-	fi
+	for REG in ${DST_NODES}; do # Probably doing both pixel and gridline registered output, except for master */
+		DST_FILE=${DST_PREFIX}_${RES}${UNIT}${REG}.grd
+		grdtitle="${TITLE} at ${RES} arc ${UNIT_NAME}"
+		# Note: The ${SRC_ORIG/+/\\+} below is to escape any plus-symbols in the file name with a backslash so grdedit -D will work
+		if [ -f ${DST_FILE} ]; then	# Do nothing
+			echo "${DST_FILE} exist - skipping"
+		elif [ "X${MASTER}" = "Xmaster" ]; then # Just make a copy of the master to a new output file
+			if [ ${REG} = ${SRC_REG} ]; then # Only do the matching node registration for master
+				echo "Convert ${SRC_FILE} to ${DST_FILE}=${DST_FORMAT}"
+				gmt grdconvert ${SRC_FILE} ${DST_FILE}=${DST_FORMAT} --IO_NC4_DEFLATION_LEVEL=9
+				remark="Reformatted from master file ${SRC_ORIG/+/\\+} [${REMARK}]"
+				gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
+			fi
+		else	# Must down-sample to a lower resolution via spherical Gaussian filtering
+			# Get suitable Gaussian full-width filter rounded to nearest 0.1 km after adding 50 meters for noise
+			echo "Down-filter ${SRC_FILE} to ${DST_FILE}=${DST_FORMAT}"
+			FILTER_WIDTH=`gmt math -Q ${SRC_RADIUS} 2 MUL PI MUL 360 DIV $INC MUL 0.05 ADD 10 MUL RINT 10 DIV =`
+			gmt grdfilter ${SRC_FILE} -Fg${FILTER_WIDTH} -D${FMODE} -I${RES}${UNIT} -r${REG} -G${DST_FILE}=${DST_FORMAT} --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=${CHUNK} --PROJ_ELLIPSOID=Sphere
+			remark="Obtained by Gaussian ${DST_MODE} filtering (${FILTER_WIDTH} km fullwidth) from ${SRC_FILE/+/\\+} [${REMARK}]"
+			gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
+		fi
+	done
 done < /tmp/res.lis
 # 10. Clean up /tmp
 rm -f /tmp/res.lis /tmp/par.sh

--- a/scripts/srv_downsampler.sh
+++ b/scripts/srv_downsampler.sh
@@ -111,7 +111,7 @@ while read RES UNIT CHUNK MASTER; do
 		UNIT_NAME="${UNIT_NAME}s"
 	fi
 	for REG in ${DST_NODES}; do # Probably doing both pixel and gridline registered output, except for master */
-		DST_FILE=${DST_PREFIX}_${RES}${UNIT}${REG}.grd
+		DST_FILE=${DST_PREFIX}_${RES}${UNIT}_${REG}.grd
 		grdtitle="${TITLE} at ${RES} arc ${UNIT_NAME}"
 		# Note: The ${SRC_ORIG/+/\\+} below is to escape any plus-symbols in the file name with a backslash so grdedit -D will work
 		if [ -f ${DST_FILE} ]; then	# Do nothing


### PR DESCRIPTION
A really bad thing to do is to take a gridline-registered grid and resample it to pixel registration.  The common man thinks this is fine, but below we show why this is horrible.

![Fig2_grid2pix](https://user-images.githubusercontent.com/26473567/82402964-7231e380-99f9-11ea-9c9d-755958c1ba83.jpg)

The red dots represents the Nyquist wavelength component in the gridline-registered data (say, for some row) and we want to resample at the pixel nodes (triangles). You can see there is no amplitude there, hence the Nyquist signal is completely lost.  Lower frequencies have less loss, but it remains pretty bad: below is the transfer function going from one to the other registration:

![Fig2_grid2pix_transfer](https://user-images.githubusercontent.com/26473567/82403136-d2288a00-99f9-11ea-81b6-d9a2354f0492.jpg)

Therefore, w a master grid file should not be changed from one registration to another without a severe loss of the highest frequencies, for the downsampling we can create both pixel and gridline versions of whatever the master file was.  This is helpful when you need to co-registered other data sets, especially images which usually are pixel registered - in contrast, lots of geophysical data are gridline registered.  Rather than screwing up trying to change a 6m gridline to pixel, way better to use our 6m pixel downsampled form the higher resolutions. Figures from my data analysis notes are modified from [@WalterHFSmith  work](https://link.springer.com/article/10.1007/s11001-005-2095-4).

This PR adds a list of comma-separated registrations to the recipe file, and the _srv_downsampler.sh_ loops over these to build both versions, except for master.