### PR TITLE
Update data server file and link script

### DIFF
--- a/information/gmt_data_server.txt
+++ b/information/gmt_data_server.txt
@@ -8,20 +8,20 @@
 #
 # Symbolic links for convenience and backwards compatibility with GMT <= 6.0.0; these points to the gridline-registered versions below (except 15s which is pixel only)
 #
-/server/				earth_relief_60m.grd	60m	g	128K	Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_01d.grd	01d	g	128K	Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_30m.grd	30m	g	435K	Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_20m.grd	20m	g	918K	Earth Relief at 20x20 arc minutes from Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_15m.grd	15m	g	1.6M	Earth Relief at 15x15 arc minutes from Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_10m.grd	10m	g	3.4M	Earth Relief at 10x10 arc minutes from Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_06m.grd	06m	g	8.8M	Earth Relief at 6x6 arc minutes from Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_05m.grd	05m	g	 13M	Earth Relief at 5x5 arc minutes from Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_04m.grd	04m	g	 19M	Earth Relief at 4x4 arc minutes from Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_03m.grd	03m	g	 33M	Earth Relief at 3x3 arc minutes from Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_02m.grd	02m	g	 71M	Earth Relief at 2x2 arc minutes from Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_01m.grd	01m	g	258M	Earth Relief at 1x1 arc minutes from Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_30s.grd	30s	g	935M	Earth Relief at 30x30 arc seconds from Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/				earth_relief_15s.grd	15s	p	3.2G	Earth Relief at 15x15 arc seconds provided by SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_60m.grd	60m	g	128K	Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_01d.grd	01d	g	128K	Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_30m.grd	30m	g	435K	Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_20m.grd	20m	g	918K	Earth Relief at 20x20 arc minutes from Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_15m.grd	15m	g	1.6M	Earth Relief at 15x15 arc minutes from Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_10m.grd	10m	g	3.4M	Earth Relief at 10x10 arc minutes from Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_06m.grd	06m	g	8.8M	Earth Relief at 6x6 arc minutes from Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_05m.grd	05m	g	 13M	Earth Relief at 5x5 arc minutes from Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_04m.grd	04m	g	 19M	Earth Relief at 4x4 arc minutes from Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_03m.grd	03m	g	 33M	Earth Relief at 3x3 arc minutes from Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_02m.grd	02m	g	 71M	Earth Relief at 2x2 arc minutes from Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_01m.grd	01m	g	258M	Earth Relief at 1x1 arc minutes from Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_30s.grd	30s	g	935M	Earth Relief at 30x30 arc seconds from Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth_relief/	earth_relief_15s.grd	15s	p	3.2G	Earth Relief at 15x15 arc seconds provided by SRTM15+V2.1 [Tozer et al., 2019]
 #
 # Special names for files based on tiles.  These are virtual files that never exist
 #

--- a/scripts/srv_setbackwards_links.sh
+++ b/scripts/srv_setbackwards_links.sh
@@ -4,10 +4,10 @@
 # Creates symbolic links to the earth_relief/earth_relief_xxy.grd files
 # that were known prior to GMT 6.1.  For older GMT versions we need
 # symbolic links in the root (/export/gmtserver/gmt/data) directory,
-# while for GMT 6.1 we need links in the server directory instead.
-# This script creates both sets of links
+# while for GMT 6.1 we need links in the server/earth_relief directory
+# instead. This script creates both sets of links.
 
-# 1. Make the list of the resolutions and the registrations
+# 0. Make the list of the resolutions and the registrations
 cat << EOF > /tmp/tmp.lis
 01d	g
 30m	g
@@ -24,19 +24,24 @@ cat << EOF > /tmp/tmp.lis
 15s	p
 EOF
 
-# 2a. Make the links in the root dir
+# 1. Go to the root of the data service
 cd /export/gmtserver/gmt/data
+
+# 2. Delete the old links wherever they are found
+rm -f earth_relief_???.grd server/earth_relief_???.grd server/earth_relief/earth_relief_???.grd 
+
+# 3a. Make the links in the root dir
 while read xxy registration; do
 	ln -s server/earth_relief/earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd
 done < /tmp/tmp.lis
-# Manually do the 60m -> lis link
+# 3b. Manually do the 60m -> lis link
 ln -s server/earth_relief/earth_relief_01d_g.grd earth_relief_60m.grd
 
-# 2b. Make the links in the server dir
-cd /export/gmtserver/gmt/data/server
+# 4a. Make the links in the earth_relief dir
+cd /export/gmtserver/gmt/data/server/earth_relief
 while read xxy registration; do
-	ln -s earth_relief/earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd
+	ln -s earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd
 done < /tmp/tmp.lis
-# Manually do the 60m -> lis link
-ln -s earth_relief/earth_relief_01d_g.grd earth_relief_60m.grd
+# 4b. Manually do the 60m -> lis link
+ln -s earth_relief_01d_g.grd earth_relief_60m.grd
 rm -f /tmp/tmp.lis


### PR DESCRIPTION
We decide that for GMT 6.1 any earth_relief file obtained by a link with the old names should be written to the server/earth_relief directory on the local machine.  This is now reflected in the table.  The srv_setbackwards_links.sh removes any old links and creates them.  This script is only meant to be run manually, probably just once, but it serves as a log of what happened.