### PR TITLE
More flexible server directory layout

### DIFF
--- a/information/gmt_data_server.txt
+++ b/information/gmt_data_server.txt
@@ -1,7 +1,9 @@
-# Information about all the remote data sets available on the GMT Data server
+# Master table with information about all the remote data sets available on the GMT Data server
+# Changes related to data on the gmtserver must be added into this file before they are available to users
+#
 # Updated May 26, 2020
-# Note: The crontab script srv_git_update.sh will count non-commented lines and write that count, then
-#       append the contents of this file and place it in the data directory. It is that file that is synced by users.
+# Note: The crontab script srv_git_update.sh will count non-commented lines and write that count, then append
+#       the contents of this file and place it in the data directory. It is that file that is synced by users.
 #
 #----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # Dir			Name					xxy	reg	size    Remark

--- a/information/gmt_data_server.txt
+++ b/information/gmt_data_server.txt
@@ -1,27 +1,27 @@
 # Information about all the remote data sets available on the GMT Data server
-# Updated May 25, 2020
+# Updated May 26, 2020
 # Note: The crontab script srv_git_update.sh will count non-commented lines and write that count, then
-#       append the contents of this file and place it in the data directory. That file is synced by users.
+#       append the contents of this file and place it in the data directory. It is that file that is synced by users.
 #
 #----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # Dir			Name					xxy	reg	size    Remark
 #
 # Symbolic links for convenience and backwards compatibility with GMT <= 6.0.0; these points to the gridline-registered versions below (except 15s which is pixel only)
 #
-/server/earth_relief/	earth_relief_60m.grd	60m	g	128K	Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_01d.grd	01d	g	128K	Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_30m.grd	30m	g	435K	Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_20m.grd	20m	g	918K	Earth Relief at 20x20 arc minutes from Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_15m.grd	15m	g	1.6M	Earth Relief at 15x15 arc minutes from Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_10m.grd	10m	g	3.4M	Earth Relief at 10x10 arc minutes from Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_06m.grd	06m	g	8.8M	Earth Relief at 6x6 arc minutes from Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_05m.grd	05m	g	 13M	Earth Relief at 5x5 arc minutes from Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_04m.grd	04m	g	 19M	Earth Relief at 4x4 arc minutes from Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_03m.grd	03m	g	 33M	Earth Relief at 3x3 arc minutes from Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_02m.grd	02m	g	 71M	Earth Relief at 2x2 arc minutes from Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_01m.grd	01m	g	258M	Earth Relief at 1x1 arc minutes from Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_30s.grd	30s	g	935M	Earth Relief at 30x30 arc seconds from Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_15s.grd	15s	p	3.2G	Earth Relief at 15x15 arc seconds provided by SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_60m.grd	60m	g	128K	Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_01d.grd	01d	g	128K	Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_30m.grd	30m	g	435K	Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_20m.grd	20m	g	918K	Earth Relief at 20x20 arc minutes from Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_15m.grd	15m	g	1.6M	Earth Relief at 15x15 arc minutes from Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_10m.grd	10m	g	3.4M	Earth Relief at 10x10 arc minutes from Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_06m.grd	06m	g	8.8M	Earth Relief at 6x6 arc minutes from Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_05m.grd	05m	g	 13M	Earth Relief at 5x5 arc minutes from Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_04m.grd	04m	g	 19M	Earth Relief at 4x4 arc minutes from Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_03m.grd	03m	g	 33M	Earth Relief at 3x3 arc minutes from Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_02m.grd	02m	g	 71M	Earth Relief at 2x2 arc minutes from Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_01m.grd	01m	g	258M	Earth Relief at 1x1 arc minutes from Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_30s.grd	30s	g	935M	Earth Relief at 30x30 arc seconds from Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_15s.grd	15s	p	3.2G	Earth Relief at 15x15 arc seconds provided by SRTM15+V2.1 [Tozer et al., 2019]
 #
 # Special names for files based on tiles.  These are virtual files that never exist
 #
@@ -32,30 +32,30 @@
 #
 # Physical data sets for Earth DEM
 #
-/server/earth_relief/	earth_relief_60m_g.grd	60m	g	128K	Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_01d_g.grd	01d	g	128K	Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_30m_g.grd	30m	g	435K	Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_20m_g.grd	20m	g	918K	Earth Relief at 20x20 arc minutes from Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_15m_g.grd	15m	g	1.6M	Earth Relief at 15x15 arc minutes from Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_10m_g.grd	10m	g	3.4M	Earth Relief at 10x10 arc minutes from Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_06m_g.grd	06m	g	8.8M	Earth Relief at 6x6 arc minutes from Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_05m_g.grd	05m	g	 13M	Earth Relief at 5x5 arc minutes from Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_04m_g.grd	04m	g	 19M	Earth Relief at 4x4 arc minutes from Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_03m_g.grd	03m	g	 33M	Earth Relief at 3x3 arc minutes from Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_02m_g.grd	02m	g	 71M	Earth Relief at 2x2 arc minutes from Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_01m_g.grd	01m	g	258M	Earth Relief at 1x1 arc minutes from Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_30s_g.grd	30s	g	935M	Earth Relief at 30x30 arc seconds from Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_60m_p.grd	60m	p	128K	Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_01d_p.grd	01d	p	128K	Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_30m_p.grd	30m	p	435K	Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_20m_p.grd	20m	p	918K	Earth Relief at 20x20 arc minutes from Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_15m_p.grd	15m	p	1.6M	Earth Relief at 15x15 arc minutes from Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_10m_p.grd	10m	p	3.4M	Earth Relief at 10x10 arc minutes from Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_06m_p.grd	06m	p	8.8M	Earth Relief at 6x6 arc minutes from Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_05m_p.grd	05m	p	 13M	Earth Relief at 5x5 arc minutes from Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_04m_p.grd	04m	p	 19M	Earth Relief at 4x4 arc minutes from Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_03m_p.grd	03m	p	 33M	Earth Relief at 3x3 arc minutes from Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_02m_p.grd	02m	p	 71M	Earth Relief at 2x2 arc minutes from Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_01m_p.grd	01m	p	258M	Earth Relief at 1x1 arc minutes from Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_30s_p.grd	30s	p	935M	Earth Relief at 30x30 arc seconds from Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
-/server/earth_relief/	earth_relief_15s_p.grd	15s	p	3.2G	Earth Relief at 15x15 arc seconds provided by SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_60m_g.grd	60m	g	128K	Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_01d_g.grd	01d	g	128K	Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_30m_g.grd	30m	g	435K	Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_20m_g.grd	20m	g	918K	Earth Relief at 20x20 arc minutes from Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_15m_g.grd	15m	g	1.6M	Earth Relief at 15x15 arc minutes from Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_10m_g.grd	10m	g	3.4M	Earth Relief at 10x10 arc minutes from Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_06m_g.grd	06m	g	8.8M	Earth Relief at 6x6 arc minutes from Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_05m_g.grd	05m	g	 13M	Earth Relief at 5x5 arc minutes from Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_04m_g.grd	04m	g	 19M	Earth Relief at 4x4 arc minutes from Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_03m_g.grd	03m	g	 33M	Earth Relief at 3x3 arc minutes from Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_02m_g.grd	02m	g	 71M	Earth Relief at 2x2 arc minutes from Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_01m_g.grd	01m	g	258M	Earth Relief at 1x1 arc minutes from Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_30s_g.grd	30s	g	935M	Earth Relief at 30x30 arc seconds from Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_60m_p.grd	60m	p	128K	Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_01d_p.grd	01d	p	128K	Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_30m_p.grd	30m	p	435K	Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_20m_p.grd	20m	p	918K	Earth Relief at 20x20 arc minutes from Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_15m_p.grd	15m	p	1.6M	Earth Relief at 15x15 arc minutes from Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_10m_p.grd	10m	p	3.4M	Earth Relief at 10x10 arc minutes from Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_06m_p.grd	06m	p	8.8M	Earth Relief at 6x6 arc minutes from Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_05m_p.grd	05m	p	 13M	Earth Relief at 5x5 arc minutes from Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_04m_p.grd	04m	p	 19M	Earth Relief at 4x4 arc minutes from Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_03m_p.grd	03m	p	 33M	Earth Relief at 3x3 arc minutes from Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_02m_p.grd	02m	p	 71M	Earth Relief at 2x2 arc minutes from Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_01m_p.grd	01m	p	258M	Earth Relief at 1x1 arc minutes from Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_30s_p.grd	30s	p	935M	Earth Relief at 30x30 arc seconds from Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]
+/server/earth/earth_relief/	earth_relief_15s_p.grd	15s	p	3.2G	Earth Relief at 15x15 arc seconds provided by SRTM15+V2.1 [Tozer et al., 2019]

--- a/scripts/srv_setbackwards_links.sh
+++ b/scripts/srv_setbackwards_links.sh
@@ -4,7 +4,7 @@
 # When the @remotefiles was first introduced in GMT 5.x and continued
 # in GMT 6.0.0, we looked for the earth_relief_xxy.grd files in the
 # top of the gmtserver directory (/export/gmtserver/gmt/data). This
-# has to continue to work as we make changes for 6.1.  THe solution
+# has to continue to work as we make changes for 6.1.  The solution
 # is to create symbolic links from where 6.x/6.0.0 expects the files
 # to where the files will be.  For the earth_relief files, this is
 # now in server/earth/earth_relief.

--- a/scripts/srv_setbackwards_links.sh
+++ b/scripts/srv_setbackwards_links.sh
@@ -1,11 +1,19 @@
 #!/bin/bash -e
 # srv_setbackwards_links.sh
 #
-# Creates symbolic links to the earth_relief/earth_relief_xxy.grd files
-# that were known prior to GMT 6.1.  For older GMT versions we need
-# symbolic links in the root (/export/gmtserver/gmt/data) directory,
-# while for GMT 6.1 we need links in the server/earth_relief directory
-# instead. This script creates both sets of links.
+# When the @remotefiles was first introduced in GMT 5.x and continued
+# in GMT 6.0.0, we looked for the earth_relief_xxy.grd files in the
+# top of the gmtserver directory (/export/gmtserver/gmt/data). This
+# has to continue to work as we make changes for 6.1.  THe solution
+# is to create symbolic links from where 6.x/6.0.0 expects the files
+# to where the files will be.  For the earth_relief files, this is
+# now in server/earth/earth_relief.
+#
+# Creates symbolic links to:
+#	 server/earth/earth_reliefearth_relief_xxy.grd
+# For older GMT versions we need symbolic links in the root
+# while for GMT 6.1 we need links in the same directory as the files.
+# This script creates both sets of links
 
 # 0. Make the list of the resolutions and the registrations
 cat << EOF > /tmp/tmp.lis
@@ -28,20 +36,21 @@ EOF
 cd /export/gmtserver/gmt/data
 
 # 2. Delete the old links wherever they are found
-rm -f earth_relief_???.grd server/earth_relief_???.grd server/earth_relief/earth_relief_???.grd 
+rm -f earth_relief_???.grd server/earth_relief_???.grd server/earth/earth_relief/earth_relief_???.grd 
 
-# 3a. Make the links in the root dir
+# 3a. Make the backwards compatible 6.0.0 links in the root dir
 while read xxy registration; do
 	ln -s server/earth_relief/earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd
 done < /tmp/tmp.lis
-# 3b. Manually do the 60m -> lis link
+# 3b. Manually do the 60m -> 01d link since there is no 60m source anymore
 ln -s server/earth_relief/earth_relief_01d_g.grd earth_relief_60m.grd
 
 # 4a. Make the links in the earth_relief dir
-cd /export/gmtserver/gmt/data/server/earth_relief
+cd /export/gmtserver/gmt/data/server/earth/earth_relief
 while read xxy registration; do
 	ln -s earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd
 done < /tmp/tmp.lis
-# 4b. Manually do the 60m -> lis link
+# 4b. Manually do the 60m -> 01d link since there is no 60m source anymore
 ln -s earth_relief_01d_g.grd earth_relief_60m.grd
+# 5. Remote tempfile
 rm -f /tmp/tmp.lis

--- a/scripts/srv_setbackwards_links.sh
+++ b/scripts/srv_setbackwards_links.sh
@@ -36,7 +36,7 @@ EOF
 cd /export/gmtserver/gmt/data
 
 # 2. Delete the old links wherever they are found
-rm -f earth_relief_???.grd server/earth_relief_???.grd server/earth/earth_relief/earth_relief_???.grd 
+find . -name 'earth_relief_???.grd' -exec rm -f {} \; 
 
 # 3a. Make the backwards compatible 6.0.0 links in the root dir
 while read xxy registration; do


### PR DESCRIPTION
As per #44, make one directory **per** planetary body under server, with actual files under separate subdirectories, one per data set.  For our DEMs (the only data yet up there), we have all the files in server/earth/earth_relief/earth_relif_xxy_g|p.grd, with a set of backwards compatible links in root (for GMT <= 6.0.0) and in the same dir as the data files (for GMT >= 6.1.0 using old grid names).