### PR TITLE
Let link sript take optional root and set links to pixel grids

### DIFF
--- a/scripts/srv_setbackwards_links.sh
+++ b/scripts/srv_setbackwards_links.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# srv_setbackwards_links.sh
+# srv_setbackwards_links.sh [root]
 #
 # When the @remotefiles was first introduced in GMT 5.x and continued
 # in GMT 6.0.0, we looked for the earth_relief_xxy.grd files in the
@@ -19,23 +19,27 @@
 
 # 0. Make the list of the resolutions and the registrations
 cat << EOF > /tmp/tmp.lis
-01d	g
-30m	g
-20m	g
-15m	g
-10m	g
-06m	g
-05m	g
-04m	g
-03m	g
-02m	g
-01m	g
-30s	g
+01d	p
+30m	p
+20m	p
+15m	p
+10m	p
+06m	p
+05m	p
+04m	p
+03m	p
+02m	p
+01m	p
+30s	p
 15s	p
 EOF
 
-# 1. Go to the root of the data service
-cd /export/gmtserver/gmt/data
+# 1. Go to the root of the data service, or alternatively another tree
+if [ "X${1}" = "X" ]; then
+	cd /export/gmtserver/gmt/data
+else
+	cd /export/gmtserver/gmt/${1}
+fi
 
 # 2. Delete the old links wherever they are found
 find . -name 'earth_relief_???.grd' -exec rm -f {} \; 
@@ -45,7 +49,7 @@ while read xxy registration; do
 	ln -s server/earth/earth_relief/earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd
 done < /tmp/tmp.lis
 # 3b. Manually do the 60m -> 01d link since there is no 60m source anymore
-ln -s server/earth/earth_relief/earth_relief_01d_g.grd earth_relief_60m.grd
+ln -s server/earth/earth_relief/earth_relief_01d_p.grd earth_relief_60m.grd
 
 # 4a. Make the links in the earth_relief dir
 cd /export/gmtserver/gmt/data/server/earth/earth_relief
@@ -53,6 +57,6 @@ while read xxy registration; do
 	ln -s earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd
 done < /tmp/tmp.lis
 # 4b. Manually do the 60m -> 01d link since there is no 60m source anymore
-ln -s earth_relief_01d_g.grd earth_relief_60m.grd
+ln -s earth_relief_01d_p.grd earth_relief_60m.grd
 # 5. Remote tempfile
 rm -f /tmp/tmp.lis


### PR DESCRIPTION
Per discussion, we will use the pixel grids as the default.  The other change is to give another root dir name [data] to change the links in that tree (e.g., test).  I have set up a symbolic link test that points to the data_6.1 directory (data points to data_6.0) and added a forward so that developers can use test.generic-mapping-tools.org to pull data from the test dir (will make changes in GMT to make this easier).
