### PR TITLE
Separate out format, scale and offset parameters

### DIFF
--- a/recipes/earth_age.recipe
+++ b/recipes/earth_age.recipe
@@ -1,4 +1,7 @@
 # Recipe file for down-filtering seafloor ages grid
+# 2020-05-28 PW
+#
+# We use a precision of 0.01 Myr which requires an offset of 100 Myr to fit in 16-bit ints
 #
 # To be given as input file to script srv_downsampler.sh
 #
@@ -9,13 +12,16 @@
 # SRC_REMARK="Seton_et_al.,_2020;_in_prep"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=ages
-# SRC_UNIT=My
+# SRC_UNIT=Myr
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
 # DST_NODES=g,p
+# DST_PLANET=earth
 # DST_PREFIX=earth_age
-# DST_FORMAT=ns+sa
+# DST_FORMAT=ns
+# DST_SCALE=0.01
+# DST_OFFSET=100
 # DST_TILE_TAG=ER
 # DST_TILE_SIZE=1200
 #

--- a/recipes/earth_relief.recipe
+++ b/recipes/earth_relief.recipe
@@ -1,4 +1,7 @@
 # Recipe file for down-filtering SRTM15s
+# 2020-05-28 PW
+#
+# We use a precision of 0.5 m with a zero offset to fit in 16-bit ints
 #
 # To be given as input file to script srv_downsampler.sh
 #
@@ -14,8 +17,11 @@
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
 # DST_NODES=g,p
+# DST_PLANET=earth
 # DST_PREFIX=earth_relief
-# DST_FORMAT=ns+sa
+# DST_FORMAT=ns
+# DST_SCALE=0.5
+# DST_OFFSET=0
 # DST_TILE_TAG=ER
 # DST_TILE_SIZE=1200
 #

--- a/scripts/srv_downsampler.sh
+++ b/scripts/srv_downsampler.sh
@@ -51,11 +51,14 @@ grep DST_MODE $RECIPE   | awk '{print $2}' >> /tmp/par.sh
 grep DST_NODES $RECIPE  | awk '{print $2}' >> /tmp/par.sh
 grep DST_PREFIX $RECIPE | awk '{print $2}' >> /tmp/par.sh
 grep DST_FORMAT $RECIPE | awk '{print $2}' >> /tmp/par.sh
+grep DST_SCALE $RECIPE  | awk '{print $2}' >> /tmp/par.sh
+grep DST_OFFSET $RECIPE | awk '{print $2}' >> /tmp/par.sh
 source /tmp/par.sh
 
-# 4. Get the file name of the source file
+# 4. Get the file name of the source file and output modifiers
 SRC_BASENAME=`basename ${SRC_FILE}`
 SRC_ORIG=${SRC_BASENAME}
+DST_MODIFY=${FORMAT}+s${DST_SCALE}+o${DST_OFFSET}
 
 # 5. Determine if this source is an URL and if we need to download it first
 is_url=`echo ${SRC_FILE} | grep -c :`
@@ -118,16 +121,16 @@ while read RES UNIT CHUNK MASTER; do
 			echo "${DST_FILE} exist - skipping"
 		elif [ "X${MASTER}" = "Xmaster" ]; then # Just make a copy of the master to a new output file
 			if [ ${REG} = ${SRC_REG} ]; then # Only do the matching node registration for master
-				echo "Convert ${SRC_FILE} to ${DST_FILE}=${DST_FORMAT}"
-				gmt grdconvert ${SRC_FILE} ${DST_FILE}=${DST_FORMAT} --IO_NC4_DEFLATION_LEVEL=9
+				echo "Convert ${SRC_FILE} to ${DST_FILE}=${DST_MODIFY}"
+				gmt grdconvert ${SRC_FILE} ${DST_FILE}=${DST_MODIFY} --IO_NC4_DEFLATION_LEVEL=9
 				remark="Reformatted from master file ${SRC_ORIG/+/\\+} [${REMARK}]"
 				gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
 			fi
 		else	# Must down-sample to a lower resolution via spherical Gaussian filtering
 			# Get suitable Gaussian full-width filter rounded to nearest 0.1 km after adding 50 meters for noise
-			echo "Down-filter ${SRC_FILE} to ${DST_FILE}=${DST_FORMAT}"
+			echo "Down-filter ${SRC_FILE} to ${DST_FILE}=${DST_MODIFY}"
 			FILTER_WIDTH=`gmt math -Q ${SRC_RADIUS} 2 MUL PI MUL 360 DIV $INC MUL 0.05 ADD 10 MUL RINT 10 DIV =`
-			gmt grdfilter ${SRC_FILE} -Fg${FILTER_WIDTH} -D${FMODE} -I${RES}${UNIT} -r${REG} -G${DST_FILE}=${DST_FORMAT} --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=${CHUNK} --PROJ_ELLIPSOID=Sphere
+			gmt grdfilter ${SRC_FILE} -Fg${FILTER_WIDTH} -D${FMODE} -I${RES}${UNIT} -r${REG} -G${DST_FILE}=${DST_MODIFY} --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=${CHUNK} --PROJ_ELLIPSOID=Sphere
 			remark="Obtained by Gaussian ${DST_MODE} filtering (${FILTER_WIDTH} km fullwidth) from ${SRC_FILE/+/\\+} [${REMARK}]"
 			gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
 		fi


### PR DESCRIPTION
Rather than give format as ns**+s**_scale_**+o**_offset_, it is more flexible for scripting if these are separate parameters in the recipe file. The tiler script will need to get the reciprocal of the scale, for instance.