### PR TITLE
Add GMT/MEX dataset for testing as commandline version

### DIFF
--- a/scripts/srv_setbackwards_links.sh
+++ b/scripts/srv_setbackwards_links.sh
@@ -60,7 +60,7 @@ while read xxy registration; do
 	ln -s server/earth/earth_relief/earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd
 done < /tmp/files.lis
 # 3b. Manually do the 60m -> 01d link since there is no 60m source anymore
-ln -s server/earth/earth_relief/earth_relief_01d_p.grd earth_relief_60m.grd
+ln -s server/earth/earth_relief/earth_relief_01d_g.grd earth_relief_60m.grd
 # 3c. Make the backwards compatible 6.0.0 links in the root dir to files in the root dir
 while read xxy registration; do
 	ln -s earth_relief_${xxy}_${registration}.grd earth_relief_${xxy}.grd


### PR DESCRIPTION
Example 3 in the GMT/MEX paper extracts layers from a nasty HDF5 file we process via GDAL.  This is a good test for GMT as well but is too big (22 Mb) to add to the test dir - hence need it in the cache.