### PR TITLE
Add recipes for Sandwell geographic, non-180 latitude range grids

### DIFF
--- a/recipes/earth_grav.recipe
+++ b/recipes/earth_grav.recipe
@@ -1,0 +1,40 @@
+# Recipe file for down-filtering Sandwell FAA gravity grid
+# 2020-11-07 PW
+#
+# We use a precision of 0.025 mGal
+# This is based on the raw data file for version 30.
+# The range of -401.572967529 to 942.61932373 mGal means we may use offset of 300 and scale of 0.025
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/grav_30.1.nc
+# SRC_TITLE=Earth_Gravity
+# SRC_REMARK="Sandwell_et_al.,_2014;_http://dx.doi.org/10.1126/science.1258213"
+# SRC_RADIUS=6371.0087714
+# SRC_NAME=oceanfaa
+# SRC_UNIT=mGal
+#
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=earth
+# DST_PREFIX=earth_oceanfaa
+# DST_FORMAT=ns
+# DST_SCALE=0.025
+# DST_OFFSET=300
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+01		m		30		4096	master
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		1024
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/recipes/earth_oceanfaa.recipe
+++ b/recipes/earth_oceanfaa.recipe
@@ -11,7 +11,7 @@
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/grav_30.1.nc
-# SRC_TITLE=Earth_Ocean_Free_Air_Anomalies
+# SRC_TITLE=Earth_Ocean_Free_Air_Gravity_Anomalies
 # SRC_REMARK="Sandwell_et_al.,_2014;_http://dx.doi.org/10.1126/science.1258213"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=oceanfaa

--- a/recipes/earth_oceanfaa.recipe
+++ b/recipes/earth_oceanfaa.recipe
@@ -11,7 +11,7 @@
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/grav_30.1.nc
-# SRC_TITLE=Earth_Gravity
+# SRC_TITLE=Earth_Ocean_Free_Air_Anomalies
 # SRC_REMARK="Sandwell_et_al.,_2014;_http://dx.doi.org/10.1126/science.1258213"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=oceanfaa

--- a/recipes/earth_oceanfaa.recipe
+++ b/recipes/earth_oceanfaa.recipe
@@ -3,7 +3,7 @@
 #
 # We use a precision of 0.025 mGal
 # This is based on the raw data file for version 30.
-# The range of -401.572967529 to 942.61932373 mGal means we may use offset of 300 and scale of 0.025
+# The range of -401.572967529 to +942.61932373 mGal means we may use offset of 300 and scale of 0.025
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #

--- a/recipes/earth_oceanfaa.recipe
+++ b/recipes/earth_oceanfaa.recipe
@@ -4,6 +4,7 @@
 # We use a precision of 0.025 mGal
 # This is based on the raw data file for version 30.
 # The range of -401.572967529 to +942.61932373 mGal means we may use offset of 300 and scale of 0.025
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.025 = 1/40)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #

--- a/recipes/earth_oceanvgg.recipe
+++ b/recipes/earth_oceanvgg.recipe
@@ -1,9 +1,10 @@
 # Recipe file for down-filtering Sandwell VGG grid
 # 2020-11-07 PW
 #
-# We use a precision of 0.03 Eotvos
+# We use a precision of 0.03125 Eotvos
 # This is based on the raw data file for version 30.
-# The range of -806.440856934 to +1070.05725098 Eotvos means we may use offset of 100 and scale of 0.03
+# The range of -806.440856934 to +1070.05725098 Eotvos means we may use offset of 100 and scale of 0.03125
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.03125 = 1/32)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #

--- a/recipes/earth_oceanvgg.recipe
+++ b/recipes/earth_oceanvgg.recipe
@@ -1,0 +1,40 @@
+# Recipe file for down-filtering Sandwell VGG grid
+# 2020-11-07 PW
+#
+# We use a precision of 0.03 Eotvos
+# This is based on the raw data file for version 30.
+# The range of -806.440856934 to +1070.05725098 Eotvos means we may use offset of 100 and scale of 0.03
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/curv_30.1.nc
+# SRC_TITLE=Earth_VGG
+# SRC_REMARK="Sandwell_et_al.,_2014;_http://dx.doi.org/10.1126/science.1258213"
+# SRC_RADIUS=6371.0087714
+# SRC_NAME=oceanvgg
+# SRC_UNIT=Eotvos
+#
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=earth
+# DST_PREFIX=earth_oceanvgg
+# DST_FORMAT=ns
+# DST_SCALE=0.03
+# DST_OFFSET=100
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+01		m		30		4096	master
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		1024
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/recipes/earth_oceanvgg.recipe
+++ b/recipes/earth_oceanvgg.recipe
@@ -23,7 +23,7 @@
 # DST_PLANET=earth
 # DST_PREFIX=earth_oceanvgg
 # DST_FORMAT=ns
-# DST_SCALE=0.03
+# DST_SCALE=0.03125
 # DST_OFFSET=100
 #
 # List of desired output resolution and chunk size.  Flag the source resolution with code == master

--- a/recipes/earth_oceanvgg.recipe
+++ b/recipes/earth_oceanvgg.recipe
@@ -11,7 +11,7 @@
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/curv_30.1.nc
-# SRC_TITLE=Earth_VGG
+# SRC_TITLE=Earth_Ocean_Vertical_Gravity_Gradient_Anomalies
 # SRC_REMARK="Sandwell_et_al.,_2014;_http://dx.doi.org/10.1126/science.1258213"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=oceanvgg


### PR DESCRIPTION
Dave Sandwell is distributing his near-global FAA and VGG grids in geographic netcdf format.  From those files, I can derive down-sampled and tiled versions as we do for other grids.  These files gets custom grid-scale and offsets so that we can pack as high data resolution as is reasonable in a 16-bit integer netCDF grid.  This PR adds two recipes and enhances some of the script for down-sampling:

1. Add _earth_oceanfaa.recipe_ with a precision of 0.025 mGal (0.025 = 1/40)
2. Add _earth_oceanvgg.recipe_ with a precision of 0.03125 Eotvos (0.03125 = 1/32)
3. Let s_rv_downsampler_grid.sh_ check if latitude range is less than 180 and then extend to poles with NaNs

While all this works fine and greatly compresses the data set via our JPEG2000 tiles and compressed netcdf grids, I am checking with Dave if he is able to fill in land/ocaen values the last 10 degrees to either pole as we would prefer to have a truly global grid.
I will also need to check with him regarding default CPTs he prefers for the data (since auto-scaling from master is not helpful when the data extremes of around 1000 is used to stretch a CPT).  However, I wanted to commit this while I remember the various tricks and can document them.