### PR TITLE
Add some comments related to non-running of scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,3 +2,7 @@
 
 Here are all the scripts used to maintain the server and process
 data files from the original sources.
+
+**Note**: After a clean checkout (say, after a power outage or similar),
+the hash table will not be rebuilt because fit fetch finds no new items.
+In that case I had to add a comment like this to trigger the script.

--- a/scripts/srv_do_updates.sh
+++ b/scripts/srv_do_updates.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# srv_do_updates.sh
+#
+# Called bu srv_git_update.sh when there are changes in the repo.
+# Can also be called stand-alone to initialize hash and data server tables
+# when checking out the repo for the first time.
+#
+# P. Wessel, March. 18, 2021
+
+# 1a. Change directory to top dir of working directory
+cd /export/gmtserver/gmt/gmtserver-admin
+# 1b Update the local repo
+git pull -v origin master
+# 1c Do rsync of files than may have changed to data/cache
+rsync -a --delete cache ../data
+# 1d Update the SHA256 hash table
+bash scripts/srv_update_sha256.sh
+# 1e Duplicate to the Md5 file for backwardness
+cp -f ../data/gmt_hash_server.txt ../data/gmt_md5_server.txt
+# 1f Place a copy of the data information table in the data dir with leading record indicating number of item
+grep -v '^#' information/gmt_data_server.txt | wc -l > ../data/gmt_data_server.txt
+cat information/gmt_data_server.txt >> ../data/gmt_data_server.txt

--- a/scripts/srv_do_updates.sh
+++ b/scripts/srv_do_updates.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # srv_do_updates.sh
 #
-# Called bu srv_git_update.sh when there are changes in the repo.
+# Called by srv_git_update.sh when there are changes in the repo.
 # Can also be called stand-alone to initialize hash and data server tables
 # when checking out the repo for the first time.
 #

--- a/scripts/srv_git_update.sh
+++ b/scripts/srv_git_update.sh
@@ -2,11 +2,12 @@
 # srv_git_update.sh
 #
 # Runs git pull on gmtserver and determines if any file was updated.
-# If so, runs the srv_update_sha256.sh script as well
+# If so, runs the srv_do_updates.sh script as well
 # P. Wessel, Oct. 3, 2019
 # Revised PW, May 22, 2020
 
 echo "Start Time:" $(date)
+
 # 1. Change directory to top dir of working directory
 cd /export/gmtserver/gmt/gmtserver-admin
 # Check changes and update file hash
@@ -17,17 +18,7 @@ git fetch -v origin
 # 4. Check if the local master branch is behind the remote one
 count=`git rev-list master...origin/master --count`
 if [ "$count" -ne "0" ]; then	# 5. There will be updates
-	# 5a Update the local repo
-	git pull -v origin master
-	# 5b Do rsync of files than may have changed to data/cache
-	rsync -a --delete cache ../data
-	# 5c Update the SHA256 hash table
-	bash scripts/srv_update_sha256.sh
-	# 5d Duplicate to the Md5 file for backwardness
-	cp -f ../data/gmt_hash_server.txt ../data/gmt_md5_server.txt
-	# 5e Place a copy of the data information table in the data dir with leading record indicating number of item
-	grep -v '^#' information/gmt_data_server.txt | wc -l > ../data/gmt_data_server.txt
-	cat information/gmt_data_server.txt >> ../data/gmt_data_server.txt
+	bash scripts/srv_do_updates.sh
 fi
 
 echo "End Time:" $(date)


### PR DESCRIPTION
Cloning the repo does not rebuild the hash tables until the master changes.
Maybe we need a "init" script we can run after a clean cloning that basically does the stuff inside the "if [$count.." branch? Or turn that if-branch into a srv_init_repo.sh script that is called instead, but can then also be called manually?