### PR TITLE
Add two example custom symbols

### DIFF
--- a/cache/angle.def
+++ b/cache/angle.def
@@ -1,0 +1,11 @@
+# Custom symbol showing an annotated Cartesian angle relative to the horizontal
+# Input data is expected to have x, y, angle
+N:	1 r
+0	0	M	-W0.25p,-
+1	0	D
+S
+0.25	0	M	-W0.25p
+0	0	0.5	0	$1 A
+S
+0	0	$1	0.5	v
+0.28 0.02 10p $1@. l+fHelvetica-Oblique+jBL -W- -G-

--- a/cache/angle.def
+++ b/cache/angle.def
@@ -1,11 +1,15 @@
-# Custom symbol showing an annotated Cartesian angle relative to the horizontal
+# Custom symbol showing an annotated Cartesian angle CCW relative to the horizontal
 # Input data is expected to have x, y, angle
 N:	1 r
+# Draw dashed horizontal reference line
 0	0	M	-W0.25p,-
 1	0	D
 S
+# Draw angular opening
 0.25	0	M	-W0.25p
 0	0	0.5	0	$1 A
 S
+# Place vector pointing in angle direction
 0	0	$1	0.5	v
+# Annotate the angle
 0.28 0.02 10p $1@. l+fHelvetica-Oblique+jBL -W- -G-

--- a/cache/azimuth.def
+++ b/cache/azimuth.def
@@ -1,0 +1,11 @@
+# Custom symbol showing a annotated azimuth CW relative to North
+# Input data is expected to have lon, lat, azimuth
+N:	1 a
+0	0	M	-W0.25p,-
+0	1	D
+S
+0	0.25	M	-W0.25p
+0	0	0.5	0	$1 A
+S
+0	0	$1	0.5	v
+0.02 0.28 10p $1@. l+fHelvetica-Oblique+jBL -W- -G-

--- a/cache/azimuth.def
+++ b/cache/azimuth.def
@@ -1,11 +1,15 @@
-# Custom symbol showing a annotated azimuth CW relative to North
+# Custom symbol showing an annotated azimuth CW relative to North
 # Input data is expected to have lon, lat, azimuth
 N:	1 a
+# Draw dashed North reference line
 0	0	M	-W0.25p,-
 0	1	D
 S
+# Draw angular opening
 0	0.25	M	-W0.25p
 0	0	0.5	0	$1 A
 S
+# Place vector pointing in azimuth direction
 0	0	$1	0.5	v
+# Annotate the azimuth
 0.02 0.28 10p $1@. l+fHelvetica-Oblique+jBL -W- -G-


### PR DESCRIPTION
As part as an upcoming enhancement to GMT, I am adding two simple custom symbols to the server cache:

- _angle.def_: Illustrate the direction of a Cartesian angle (CCW from the horizontal).
- _azimuth.def_: Illustrate the direction of a geographic azimuth (CW from north)

Both symbols also draw a dashed reference line (angle or azimuth equals zero), place the opening angle arc, and adds angle value as annotation.  These two symbols will be used in a new figure in the custom symbol section to explain how to deal with angles.

![angle-azim](https://user-images.githubusercontent.com/26473567/128616567-1ad10721-829f-4011-987d-2d30f1da948b.png)
