### PR TITLE
Update SRTM and add SYNBATH

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -41,7 +41,8 @@ server: [Data served by us]
 		earth_day
 		earth_night
 		earth_mask
-	    earth_relief
+		earth_relief
+		earth_synbath
 		...
 	moon
 		...

--- a/recipes/earth_synbath.recipe
+++ b/recipes/earth_synbath.recipe
@@ -1,4 +1,4 @@
-# Recipe file for down-filtering SRTM15s
+# Recipe file for down-filtering SRTM15s SYNBATH version
 # 2021-10-01 PW
 #
 # We use a precision of 0.5 m with a zero offset to fit in 16-bit ints
@@ -7,8 +7,8 @@
 #
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
-# SRC_FILE=ftp://topex.ucsd.edu/pub/srtm15_plus/SRTM15_V2.3.nc
-# SRC_TITLE=Earth_Relief
+# SRC_FILE=ftp://topex.ucsd.edu/pub/srtm15_plus/SYNBATH_V1.2.nc
+# SRC_TITLE=Earth_SYNBATH
 # SRC_REMARK="Sandwell_et_al.,_2022;_http://dx.doi.org/10.1029/xxxxxxxxxx"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=elevation
@@ -18,7 +18,7 @@
 # DST_MODE=Cartesian
 # DST_NODES=g,p
 # DST_PLANET=earth
-# DST_PREFIX=earth_relief
+# DST_PREFIX=earth_synbath
 # DST_FORMAT=ns
 # DST_SCALE=0.5
 # DST_OFFSET=0


### PR DESCRIPTION
Routine update of SRTM version and add new SYNBATH recipe. Because it takes quite a bit of memory to digest the global 15s file (360 x 180 x 240 x 240 x 4 bytes) = 11.6 Gb I need to run this at work, from home.  So please approve so I can update and start testing this remotely.  The plan is to

- Update earth_relief to the latest 2.3 version
- Add earth_synbath for a more realistic-looking bathymetry experience

I may start working with David to add his FAA and VGG grids as well.