### PR TITLE
Remove ocean from the faa and vgg products

### DIFF
--- a/recipes/earth_faa.recipe
+++ b/recipes/earth_faa.recipe
@@ -11,17 +11,17 @@
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/grav_31.1.nc
-# SRC_TITLE=Earth_Ocean_Free_Air_Gravity_Anomalies_v31
+# SRC_TITLE=Earth_Free_Air_Gravity_Anomalies_v31
 # SRC_REMARK="Sandwell_et_al.,_2014;_http://dx.doi.org/10.1126/science.1258213"
 # SRC_RADIUS=6371.0087714
-# SRC_NAME=oceanfaa
+# SRC_NAME=faa
 # SRC_UNIT=mGal
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
 # DST_NODES=g,p
 # DST_PLANET=earth
-# DST_PREFIX=earth_oceanfaa
+# DST_PREFIX=earth_faa
 # DST_FORMAT=ns
 # DST_SCALE=0.025
 # DST_OFFSET=300

--- a/recipes/earth_vgg.recipe
+++ b/recipes/earth_vgg.recipe
@@ -11,7 +11,7 @@
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/curv_31.1.nc
-# SRC_TITLE=Earth_Ocean_Vertical_Gravity_Gradient_Anomalies_v31
+# SRC_TITLE=Earth_Vertical_Gravity_Gradient_Anomalies_v31
 # SRC_REMARK="Sandwell_et_al.,_2014;_http://dx.doi.org/10.1126/science.1258213"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=vgg

--- a/recipes/earth_vgg.recipe
+++ b/recipes/earth_vgg.recipe
@@ -14,14 +14,14 @@
 # SRC_TITLE=Earth_Ocean_Vertical_Gravity_Gradient_Anomalies_v31
 # SRC_REMARK="Sandwell_et_al.,_2014;_http://dx.doi.org/10.1126/science.1258213"
 # SRC_RADIUS=6371.0087714
-# SRC_NAME=oceanvgg
+# SRC_NAME=vgg
 # SRC_UNIT=Eotvos
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
 # DST_NODES=g,p
 # DST_PLANET=earth
-# DST_PREFIX=earth_oceanvgg
+# DST_PREFIX=earth_vgg
 # DST_FORMAT=ns
 # DST_SCALE=0.03125
 # DST_OFFSET=100


### PR DESCRIPTION
Since Sandwell has included a land geopotential model in his global grids we do not need to call them _oceanfaa_ and _oceanvgg_ but can use just _faa_ and _vgg_.