### PR TITLE
Modernize scripts and add WDMAM recipe

### DIFF
--- a/recipes/earth_mag2.recipe
+++ b/recipes/earth_mag2.recipe
@@ -1,0 +1,40 @@
+# Recipe file for down-filtering the EMAG2 data sets
+# 2020-10-05 PW
+#
+# We use a precision of 0.2 nT and offset 800 nT to fit the range of -3128.5065918 to 5942.62304688 in 16-bit ints
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=https://www.ngdc.noaa.gov/geomag/data/EMAG2/EMAG2_V3_20170530/EMAG2_V3_20170530.zip
+# SRC_TITLE=Earth_MAG2_Version_3
+# SRC_REMARK="Meyer_et_al.,_2017;_https://doi.org/10.7289/V5H70CVX"
+# SRC_RADIUS=6371.0087714
+# SRC_NAME=anomaly
+# SRC_UNIT=nT
+# As source is an ASCII grid we add conversion commands (separated by ;) and original file extension
+# SRC_CUSTOM="unzip EMAG2_V3_20170530.zip ; gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,4 -Rg -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
+# SRC_EXT=zip
+#
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=earth
+# DST_PREFIX=earth_mag
+# DST_FORMAT=ns
+# DST_SCALE=0.2
+# DST_OFFSET=800
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+02		m		60		4096	master
+03		m		90		2048
+04		m		180		2048
+05		m		180		2048
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/recipes/earth_wdmam.recipe
+++ b/recipes/earth_wdmam.recipe
@@ -7,7 +7,7 @@
 #
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
-# SRC_FILE=http://wdmam.org/file/wdmam.asc
+# SRC_FILE=https://wdmam.org/file/wdmam.asc
 # SRC_TITLE=Earth_WDMAM
 # SRC_REMARK="Lesur_et_al.,_2016;_https://doi.org/10.1186/s40623-016-0404-6"
 # SRC_RADIUS=6371.0087714

--- a/recipes/earth_wdmam.recipe
+++ b/recipes/earth_wdmam.recipe
@@ -1,0 +1,39 @@
+# Recipe file for down-filtering the WDMAM data sets
+# 2020-10-05 PW
+#
+# We use a precision of 0.3 nT and offset 1400 nT to fit the range of -3128.5065918 to 5942.62304688 in 16-bit ints
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=http://wdmam.org/file/wdmam.asc
+# SRC_TITLE=Earth_WDMAM
+# SRC_REMARK="Lesur_et_al.,_2016;_https://doi.org/10.1186/s40623-016-0404-6"
+# SRC_RADIUS=6371.0087714
+# SRC_NAME=anomaly
+# SRC_UNIT=nT
+# Since source is an ASCII grid we supply conversion command and original extension
+# SRC_CUSTOM="gmt xyz2grd wdmam.asc -i0,1,2 -Rd -I3m -fg -Gwdmam.nc"
+# SRC_EXT=asc
+#
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=earth
+# DST_PREFIX=earth_wdnam
+# DST_FORMAT=ns
+# DST_SCALE=0.3
+# DST_OFFSET=1400
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+03		m		90		2048	master
+04		m		180		2048
+05		m		180		2048
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/scripts/srv_downsampler_grid.sh
+++ b/scripts/srv_downsampler_grid.sh
@@ -47,7 +47,7 @@ grep SRC_REMARK $RECIPE | awk '{print $2}' >> /tmp/par.sh
 grep SRC_RADIUS $RECIPE | awk '{print $2}' >> /tmp/par.sh
 grep SRC_NAME $RECIPE   | awk '{print $2}' >> /tmp/par.sh
 grep SRC_UNIT $RECIPE   | awk '{print $2}' >> /tmp/par.sh
-grep SRC_CUSTOM $RECIPE | awk -F'#' '{print $2}'  >> /tmp/par.sh
+grep SRC_CUSTOM $RECIPE | awk -F'#' '{print $2}' >> /tmp/par.sh
 grep SRC_EXT $RECIPE    | awk '{print $2}' >> /tmp/par.sh
 grep DST_MODE $RECIPE   | awk '{print $2}' >> /tmp/par.sh
 grep DST_NODES $RECIPE  | awk '{print $2}' >> /tmp/par.sh
@@ -76,9 +76,10 @@ fi
 if [ ! "X${SRC_CUSTOM}" = "X" ]; then	# Preprocessing data to get initial grid
 	SRC_FILE=$(basename ${SRC_FILE} ${SRC_EXT})"nc"
 	SRC_ORIG=${SRC_FILE}
-	if [ ! -f ${SRC_FILE} ]; then	# Run the custom command
+	if [ ! -f ${SRC_FILE} ]; then	# Run the custom command(s)
 		echo "srv_downsampler_grid.sh: Must convert original ${SRC_EXT} source to ${SRC_FILE}"
-		${SRC_CUSTOM}
+		$(echo ${SRC_CUSTOM} | tr '";' ' \n' > /tmp/job.sh)
+		bash /tmp/job.sh
 	fi
 fi
 

--- a/scripts/srv_downsampler_grid.sh
+++ b/scripts/srv_downsampler_grid.sh
@@ -16,16 +16,16 @@ if [ $# -eq 0 ]; then
 	exit -1
 fi
 
-if [ `uname -n` = "gmtserver" ]; then	# Doing official work on the server
+if [ $(uname -n) = "gmtserver" ]; then	# Doing official work on the server
 	TOPDIR=/export/gmtserver/gmt/gmtserver-admin
-	HERE=`pwd`
+	HERE=$(pwd)
 elif [ -d ../scripts ]; then	# On your working copy, probably in scripts
-	HERE=`pwd`
+	HERE=$(pwd)
 	cd ..
-	TOPDIR=`pwd`
+	TOPDIR=$(pwd)
 elif [ -d scripts ]; then	# On your working copy, probably in top gmtserver-admin
-	HERE=`pwd`
-	TOPDIR=`pwd`
+	HERE=$(pwd)
+	TOPDIR=$(pwd)
 else
 	echo "error: Run srv_downsampler_grid.sh from scripts folder or top gmtserver-admin directory"
 	exit -1
@@ -47,6 +47,8 @@ grep SRC_REMARK $RECIPE | awk '{print $2}' >> /tmp/par.sh
 grep SRC_RADIUS $RECIPE | awk '{print $2}' >> /tmp/par.sh
 grep SRC_NAME $RECIPE   | awk '{print $2}' >> /tmp/par.sh
 grep SRC_UNIT $RECIPE   | awk '{print $2}' >> /tmp/par.sh
+grep SRC_CUSTOM $RECIPE | awk -F'#' '{print $2}'  >> /tmp/par.sh
+grep SRC_EXT $RECIPE    | awk '{print $2}' >> /tmp/par.sh
 grep DST_MODE $RECIPE   | awk '{print $2}' >> /tmp/par.sh
 grep DST_NODES $RECIPE  | awk '{print $2}' >> /tmp/par.sh
 grep DST_PLANET $RECIPE | awk '{print $2}' >> /tmp/par.sh
@@ -57,18 +59,27 @@ grep DST_OFFSET $RECIPE | awk '{print $2}' >> /tmp/par.sh
 source /tmp/par.sh
 
 # 4. Get the file name of the source file and output modifiers
-SRC_BASENAME=`basename ${SRC_FILE}`
+SRC_BASENAME=$(basename ${SRC_FILE})
 SRC_ORIG=${SRC_BASENAME}
 DST_MODIFY=${DST_FORMAT}+s${DST_SCALE}+o${DST_OFFSET}
 
 # 5. Determine if this source is an URL and if we need to download it first
-is_url=`echo ${SRC_FILE} | grep -c :`
+is_url=$(echo ${SRC_FILE} | grep -c :)
 if [ $is_url ]; then	# Data source is an URL
 	if [ ! -f ${SRC_BASENAME} ]; then # Must download first
+		echo "srv_downsampler_grid.sh: Must download original source ${SRC_FILE}"
 		curl -k ${SRC_FILE} --output ${SRC_BASENAME}
 	fi
 	SRC_ORIG=${SRC_FILE}
 	SRC_FILE=${SRC_BASENAME}
+fi
+if [ ! "X${SRC_CUSTOM}" = "X" ]; then	# Preprocessing data to get initial grid
+	SRC_FILE=$(basename ${SRC_FILE} ${SRC_EXT})"nc"
+	SRC_ORIG=${SRC_FILE}
+	if [ ! -f ${SRC_FILE} ]; then	# Run the custom command
+		echo "srv_downsampler_grid.sh: Must convert original ${SRC_EXT} source to ${SRC_FILE}"
+		${SRC_CUSTOM}
+	fi
 fi
 
 # 6. Determine if the grid has less than full 180 latitude range.
@@ -93,8 +104,8 @@ else
 fi
 
 # 8. Replace underscores with spaces in the title and remark
-TITLE=`echo ${SRC_TITLE} | tr '_' ' '`
-REMARK=`echo ${SRC_REMARK} | tr '_' ' '`
+TITLE=$(echo ${SRC_TITLE} | tr '_' ' ')
+REMARK=$(echo ${SRC_REMARK} | tr '_' ' ')
 
 # 9. Determine filter mode
 if [ "X${DST_MODE}" = "XCartesian" ]; then
@@ -114,10 +125,10 @@ while read RES UNIT DST_TILE_SIZE CHUNK MASTER; do
 		INC=$RES
 		UNIT_NAME=degree
 	elif [ "X$UNIT" = "Xm" ]; then	# Gave increment in minutes
-		INC=`gmt math -Q $RES 60 DIV =`
+		INC=$(gmt math -Q $RES 60 DIV =)
 		UNIT_NAME=minute
 	elif [ "X$UNIT" = "Xs" ]; then	# Gave increment in seconds
-		INC=`gmt math -Q $RES 3600 DIV =`
+		INC=$(gmt math -Q $RES 3600 DIV =)
 		UNIT_NAME=second
 	elif [ "X$UNIT" = "X" ]; then	# Blank line? Skip
 		echo "Blank line - skipping"
@@ -145,7 +156,7 @@ while read RES UNIT DST_TILE_SIZE CHUNK MASTER; do
 		else	# Must down-sample to a lower resolution via spherical Gaussian filtering
 			# Get suitable Gaussian full-width filter rounded to nearest 0.1 km after adding 50 meters for noise
 			echo "Down-filter ${SRC_FILE} to ${DST_FILE}=${DST_MODIFY}"
-			FILTER_WIDTH=`gmt math -Q ${SRC_RADIUS} 2 MUL PI MUL 360 DIV $INC MUL 0.05 ADD 10 MUL RINT 10 DIV =`
+			FILTER_WIDTH=$(gmt math -Q ${SRC_RADIUS} 2 MUL PI MUL 360 DIV $INC MUL 0.05 ADD 10 MUL RINT 10 DIV =)
 			gmt grdfilter ${SRC_FILE} -Fg${FILTER_WIDTH} -D${FMODE} -I${RES}${UNIT} -r${REG} -G${DST_FILE}=${DST_MODIFY} --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=${CHUNK} --PROJ_ELLIPSOID=Sphere
 			remark="Obtained by Gaussian ${DST_MODE} filtering (${FILTER_WIDTH} km fullwidth) from ${SRC_FILE/+/\\+} [${REMARK}]"
 			gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"

--- a/scripts/srv_downsampler_image.sh
+++ b/scripts/srv_downsampler_image.sh
@@ -58,6 +58,7 @@ DST_MODIFY=${FORMAT}
 is_url=$(echo ${SRC_FILE} | grep -c :)
 if [ $is_url ]; then	# Data source is an URL
 	if [ ! -f ${SRC_BASENAME} ]; then # Must download first
+		echo "srv_downsampler_grid.sh: Must download original source ${SRC_FILE}"
 		curl -k ${SRC_FILE} --output ${SRC_BASENAME}
 	fi
 	SRC_ORIG=${SRC_FILE}

--- a/scripts/srv_earthmasks.sh
+++ b/scripts/srv_earthmasks.sh
@@ -13,16 +13,16 @@ if [ $# -eq 0 ]; then
 	exit -1
 fi
 
-if [ `uname -n` = "gmtserver" ]; then	# Doing official work on the server
+if [ $(uname -n) = "gmtserver" ]; then	# Doing official work on the server
 	TOPDIR=/export/gmtserver/gmt/gmtserver-admin
-	HERE=`pwd`
+	HERE=$(pwd)
 elif [ -d ../scripts ]; then	# On your working copy, probably in scripts
-	HERE=`pwd`
+	HERE=$(pwd)
 	cd ..
-	TOPDIR=`pwd`
+	TOPDIR=$(pwd)
 elif [ -d scripts ]; then	# On your working copy, probably in top gmtserver-admin
-	HERE=`pwd`
-	TOPDIR=`pwd`
+	HERE=$(pwd)
+	TOPDIR=$(pwd)
 else
 	echo "error: Run srv_earthmasks.sh from scripts folder or top gmtserver-admin directory"
 	exit -1
@@ -54,8 +54,8 @@ grep -v '^#' $RECIPE > /tmp/res.lis
 DST_NODES=$(echo $DST_NODES | tr ',' ' ')
 
 # 7. Replace underscores with spaces in the title and remark
-TITLE=`echo ${SRC_TITLE} | tr '_' ' '`
-REMARK=`echo ${SRC_REMARK} | tr '_' ' '`
+TITLE=$(echo ${SRC_TITLE} | tr '_' ' ')
+REMARK=$(echo ${SRC_REMARK} | tr '_' ' ')
 
 mkdir -p ${DST_PLANET}/${DST_PREFIX}
 
@@ -65,10 +65,10 @@ while read RES UNIT TILE CHUNK; do
 		INC=$RES
 		UNIT_NAME=degree
 	elif [ "X$UNIT" = "Xm" ]; then	# Gave increment in minutes
-		INC=`gmt math -Q $RES 60 DIV =`
+		INC=$(gmt math -Q $RES 60 DIV =)
 		UNIT_NAME=minute
 	elif [ "X$UNIT" = "Xs" ]; then	# Gave increment in seconds
-		INC=`gmt math -Q $RES 3600 DIV =`
+		INC=$(gmt math -Q $RES 3600 DIV =)
 		UNIT_NAME=second
 	elif [ "X$UNIT" = "X" ]; then	# Blank line? Skip
 		echo "Blank line - skipping"
@@ -81,7 +81,7 @@ while read RES UNIT TILE CHUNK; do
 		UNIT_NAME="${UNIT_NAME}s"
 	fi
 	# Get area of a grid cell at Equator in km^2 as cutoff for -A
-	MIN_AREA=`gmt math -Q ${SRC_RADIUS} PI MUL 180 DIV $INC MUL 2 POW RINT =`
+	MIN_AREA=$(gmt math -Q ${SRC_RADIUS} PI MUL 180 DIV $INC MUL 2 POW RINT =)
 	if [ $MIN_AREA -eq 0 ]; then
 		remark="All features included [${REMARK}]"
 	else

--- a/scripts/srv_git_update.sh
+++ b/scripts/srv_git_update.sh
@@ -16,7 +16,7 @@ git checkout master
 # 3. Fetch from the remote repository
 git fetch -v origin
 # 4. Check if the local master branch is behind the remote one
-count=`git rev-list master...origin/master --count`
+count=$(git rev-list master...origin/master --count)
 if [ "$count" -ne "0" ]; then	# 5. There will be updates
 	bash scripts/srv_do_updates.sh
 fi

--- a/scripts/srv_srtm_processing.sh
+++ b/scripts/srv_srtm_processing.sh
@@ -11,10 +11,10 @@
 
 # Convert things like N00E006 to a valid -R region
 function get_region  () {	# $1 is the tile tag
-	let S=`echo $1 | awk '{printf "%d\n", substr($1,2,2)}'`
-	SC=`echo $1 | awk '{printf "%c\n", substr($1,1,1)}'`
-	let W=`echo $1 | awk '{printf "%d\n", substr($1,5,3)}'`
-	WC=`echo $1 | awk '{printf "%c\n", substr($1,4,1)}'`
+	let S=$(echo $1 | awk '{printf "%d\n", substr($1,2,2)}')
+	SC=$(echo $1 | awk '{printf "%c\n", substr($1,1,1)}')
+	let W=$(echo $1 | awk '{printf "%d\n", substr($1,5,3)}')
+	WC=$(echo $1 | awk '{printf "%c\n", substr($1,4,1)}')
 	if [ $SC = "S" ]; then
 		let N=S-1
 	else
@@ -43,7 +43,7 @@ while read tile; do
 	fi
 	if [ ! -f SRTMGL${RES}_NC/${tile}.SRTMGL${RES}.nc ]; then	# Convert hgt file to compressed nc short int file
 		printf "Convert %s to NC shorts" $tile
-		region=`get_region $tile`
+		region=$(get_region $tile)
 		gmt xyz2grd -ZTLhw -I1s -R$region SRTMGL${RES}_HGT/${tile}.hgt -GSRTMGL${RES}_NC/${tile}.SRTMGL${RES}.nc=ns --IO_NC4_DEFLATION_LEVEL=9
 		printf "\n"
 	fi

--- a/scripts/srv_tiler.sh
+++ b/scripts/srv_tiler.sh
@@ -17,16 +17,16 @@
 
 function get_prefix  () {       # Takes west south and makes the {N|S}yy{W|E}xxx prefix
 	if [ $1 -ge 0 ]; then
-		X=`printf "E%03d" $1`
+		X=$(printf "E%03d" $1)
 	else
-		t=`gmt math -Q $1 NEG =`
-		X=`printf "W%03d" $t`
+		t=$(gmt math -Q $1 NEG =)
+		X=$(printf "W%03d" $t)
 	fi
 	if [ $2 -ge 0 ]; then
-		Y=`printf "N%02d" $2`
+		Y=$(printf "N%02d" $2)
 	else
-		t=`gmt math -Q $2 NEG =`
-		Y=`printf "S%02d" $t`
+		t=$(gmt math -Q $2 NEG =)
+		Y=$(printf "S%02d" $t)
 	fi
 	echo ${Y}${X}
 }
@@ -36,16 +36,16 @@ if [ $# -eq 0 ]; then
 	exit -1
 fi
 
-if [ `uname -n` = "gmtserver" ]; then	# Doing official work on the server
+if [ $(uname -n) = "gmtserver" ]; then	# Doing official work on the server
 	TOPDIR=/export/gmtserver/gmt/gmtserver-admin
-	HERE=`pwd`
+	HERE=$(pwd)
 elif [ -d ../scripts ]; then	# On your working copy, probably in scripts
-	HERE=`pwd`
+	HERE=$(pwd)
 	cd ..
-	TOPDIR=`pwd`
+	TOPDIR=$(pwd)
 elif [ -d scripts ]; then	# On your working copy, probably in top gmtserver-admin
-	HERE=`pwd`
-	TOPDIR=`pwd`
+	HERE=$(pwd)
+	TOPDIR=$(pwd)
 else
 	echo "error: Run srv_tiler.sh from scripts folder or top gmtserver-admin directory"
 	exit -1
@@ -79,16 +79,16 @@ INV_SCL=$(gmt math -Q ${DST_SCALE} INV =)
 
 export GDAL_PAM_ENABLED=NO	# We do not want XML files in the directories
 
-creation_date=`date +%Y-%m-%d`
+creation_date=$(date +%Y-%m-%d)
 rm -f ${DST_PREFIX}_dates.txt
 # 5. Loop over all the resolutions found
 while read RES UNIT DST_TILE_SIZE CHUNK MASTER ; do
 	if [ "X$UNIT" = "Xd" ]; then	# Gave increment in degrees
 		INC=$RES
 	elif [ "X$UNIT" = "Xm" ]; then	# Gave increment in minutes
-		INC=`gmt math -Q $RES 60 DIV =`
+		INC=$(gmt math -Q $RES 60 DIV =)
 	elif [ "X$UNIT" = "Xs" ]; then	# Gave increment in seconds
-		INC=`gmt math -Q $RES 3600 DIV =`
+		INC=$(gmt math -Q $RES 3600 DIV =)
 	else
 		echo "Bad resolution $RES - aborting"
 		exit -1
@@ -109,9 +109,9 @@ while read RES UNIT DST_TILE_SIZE CHUNK MASTER ; do
 		# Compute number of tiles required for this grid given nominal tile size.
 		# We enforce square tiles by only solving for ny and doubling it for nx
 		if [ $DST_TILE_SIZE -gt 0 ]; then	# OK, we need to split the file into separate tiles
-			ny=`gmt math -Q 180 ${DST_TILE_SIZE} DIV =`
-			nx=`gmt math -Q ${ny} 2 MUL =`
-			n_tiles=`gmt math -Q $nx $ny MUL =`
+			ny=$(gmt math -Q 180 ${DST_TILE_SIZE} DIV =)
+			nx=$(gmt math -Q ${ny} 2 MUL =)
+			n_tiles=$(gmt math -Q $nx $ny MUL =)
 			echo "Tiling: ${DATAGRID} split into ${n_tiles} tiles"
 			# Get dimension of tiles in degrees
 			# Build the list of w/e/s/n for the tiles
@@ -122,7 +122,7 @@ while read RES UNIT DST_TILE_SIZE CHUNK MASTER ; do
 			mkdir -p ${TILEDIR}
 			while read w e s n; do
 				# Get the {N|S}yy{W|E}xxx prefix
-				prefix=`get_prefix $w $s`
+				prefix=$(get_prefix $w $s)
 				# Create name for this tile (without extension)
 				TILEFILE=${TILEDIR}/${prefix}.${DST_TILE_TAG}.jp2
 				# Extract the tile from the global grid and write after making the integers; no compression since a tmpfile

--- a/scripts/srv_update_sha256.sh
+++ b/scripts/srv_update_sha256.sh
@@ -20,10 +20,10 @@ wc -l < /tmp/$$.lis | awk '{printf "%d\n", $1}' > $DATA/next_${GMT_HASH_TABLE}.t
 
 # 2. Loop over the files we found and update hash table if needed
 while read path; do
-	file=`basename $path`
+	file=$(basename $path)
 	if [ $path -nt $DATA/${GMT_HASH_TABLE}.txt ]; then	# File was updated after current hash table was made, redo hash
-		hash=`sha256sum $path | awk '{print $1}'`
-		size=`ls -lL $path | awk '{print $5}'`
+		hash=$(sha256sum $path | awk '{print $1}')
+		size=$(ls -lL $path | awk '{print $5}')
 		printf "%s\t%s\t%s\n" $file $hash $size >> $DATA/next_${GMT_HASH_TABLE}.txt
 	else	# Can use the previous hash record
 		grep -w $file $DATA/${GMT_HASH_TABLE}.txt >> $DATA/next_${GMT_HASH_TABLE}.txt
@@ -33,7 +33,7 @@ rm -f /tmp/$$.lis
 
 # 3. Overwrite old file with new hash table if it changed
 
-update=`diff -q $DATA/${GMT_HASH_TABLE}.txt $DATA/next_${GMT_HASH_TABLE}.txt`
+update=$(diff -q $DATA/${GMT_HASH_TABLE}.txt $DATA/next_${GMT_HASH_TABLE}.txt)
 if [ "X${update}" == "X" ]; then	# No change
 	rm -f $DATA/next_${GMT_HASH_TABLE}.txt
 else	# Keep previous and update current


### PR DESCRIPTION
This is for the [WDMAN](http://wdmam.org) and [EMAG2](https://www.ncei.noaa.gov/access/metadata/landing-page/bin/iso?id=gov.noaa.ngdc.mgg.geophysical_models:EMAG2_V3) grids. Plus eliminate back-ticks in all scripts and use $() instead for running sub-shells.
Recipe got two new optional parameters (**SRC_CUSTOM** and **SRC_EXT**) needed when the original source is not a grid but an ascii table and we must run a command to convert it to an intermediate grid (such as for **WDMAM** and **EMAG2**).