### PR TITLE
Improve script and EMAG recipes

### DIFF
--- a/recipes/earth_mag.recipe
+++ b/recipes/earth_mag.recipe
@@ -14,8 +14,9 @@
 # SRC_NAME=anomaly
 # SRC_UNIT=nT
 # As source is an ASCII grid we add conversion commands (separated by ;) and original file extension
-# SRC_CUSTOM="rm -f EMAG2_V3_20170530.nc; unzip EMAG2_V3_20170530.zip ; gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,4 -Rg -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
-# SRC_EXT=zip
+# SRC_PROCESS="rm -f EMAG2_V3_20170530.nc; unzip -n EMAG2_V3_20170530.zip"
+# SRC_CUSTOM="gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,4 -Rg -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
+# SRC_EXT=csv
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian

--- a/recipes/earth_mag4km.recipe
+++ b/recipes/earth_mag4km.recipe
@@ -14,8 +14,9 @@
 # SRC_NAME=anomaly
 # SRC_UNIT=nT
 # As source is an ASCII grid we add conversion commands (separated by ;) and original file extension
-# SRC_CUSTOM="rm -f EMAG2_V3_20170530.nc; unzip EMAG2_V3_20170530.zip ; gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,5 -Rg -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
-# SRC_EXT=zip
+# SRC_PROCESS="rm -f EMAG2_V3_20170530.nc; unzip -n EMAG2_V3_20170530.zip"
+# SRC_CUSTOM="gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,5 -Rg -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
+# SRC_EXT=csv
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian

--- a/scripts/srv_downsampler_grid.sh
+++ b/scripts/srv_downsampler_grid.sh
@@ -64,7 +64,7 @@ SRC_BASENAME=$(basename ${SRC_FILE})
 SRC_ORIG=${SRC_BASENAME}
 DST_MODIFY=${DST_FORMAT}+s${DST_SCALE}+o${DST_OFFSET}
 
-# 5.`` Determine if this source is an URL and if we need to download it first
+# 5.1 Determine if this source is an URL and if we need to download it first
 is_url=$(echo ${SRC_FILE} | grep -c :)
 if [ $is_url ]; then	# Data source is an URL
 	if [ ! -f ${SRC_BASENAME} ]; then # Must download first
@@ -74,14 +74,14 @@ if [ $is_url ]; then	# Data source is an URL
 	SRC_ORIG=${SRC_FILE}
 	SRC_FILE=${SRC_BASENAME}
 fi
-# 5.2 See if given any pre-processing steps
+# 5.2 See if given any pre-processing steps for zip files
 if [ ! "X${SRC_PROCESS}" = "X" ]; then	# Preprocessing data to get initial grid
 	echo "srv_downsampler_grid.sh: Execute pre-processing steps: ${SRC_PROCESS}"
 	$(echo ${SRC_PROCESS} | tr '";' ' \n' > /tmp/job1.sh)
 	bash /tmp/job1.sh
 	SRC_FILE=$(basename ${SRC_FILE} zip)"${SRC_EXT}"
 fi
-# 5.3 See if given any custom processing steps
+# 5.3 See if given any custom formatting steps
 if [ ! "X${SRC_CUSTOM}" = "X" ]; then	# Preprocessing data to get initial grid
 	SRC_FILE=$(basename ${SRC_FILE} ${SRC_EXT})"nc"
 	SRC_ORIG=${SRC_FILE}


### PR DESCRIPTION
For the EMAG magnetic data coming over as a zip with a single CSV table with two columns of interest, the recipe and scripts need to be able to run some commands up front (SRC_PROCESS) before continuing.  Here,  we can remove the temp nc file and extract different columns to build that netCDF file before filtering.