### PR TITLE
Update info on testing server

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -50,6 +50,21 @@ server: [Data served by us]
 		...
 ```
 
+## Manual curl test of server
+
+To just copy a file, say the gmt_data_server.txt file from oceania, try
+
+```
+curl -ks  http://oceania.generic-mapping-tools.org/gmt_data_server.txt
+```
+
+## Testing new remote data sets
+
+The testing server is called *test.generic-mapping-tools.org* so if new files are
+placed there and **GMT_DATA_SERVER** is set to *test* then gmt will try to get
+files from there.  Once files are moved to the official directory then the test
+directory should be cleaned out.
+
 ## Mirror the data server
 
 To build a mirror of the GMT data server, you need to run one of the following commands


### PR DESCRIPTION
We have added a forward to _test.generic-mapping-tools.org_ which can be used to assess new remote files placed in the test directory rather than the data directory.  if

`curl -ks  http://test.generic-mapping-tools.org/gmt_data_server.txt | head`

works then please approve.
