### PR TITLE
Fix Sandwell DOIs

### DIFF
--- a/recipes/earth_relief.recipe
+++ b/recipes/earth_relief.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering SRTM15s
-# 2021-10-06 PW
+# 2021-10-14 PW
 #
 # We use a precision of 0.5 m with a zero offset to fit in 16-bit ints
 #
@@ -9,7 +9,7 @@
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/srtm15_plus/SRTM15_V2.3.nc
 # SRC_TITLE=Earth_Relief
-# SRC_REMARK="Sandwell_et_al.,_2021;_in_review"
+# SRC_REMARK="Sandwell_et_al.,_2021;_10.1002/essoar.10508279.1"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=elevation
 # SRC_UNIT=m

--- a/recipes/earth_synbath.recipe
+++ b/recipes/earth_synbath.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering SRTM15s SYNBATH version
-# 2021-10-06 PW
+# 2021-10-14 PW
 #
 # We use a precision of 0.5 m with a zero offset to fit in 16-bit ints
 #
@@ -9,7 +9,7 @@
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/synbath/SYNBATH_V1.2.nc
 # SRC_TITLE=Earth_SYNBATH
-# SRC_REMARK="Sandwell_et_al.,_2021;_in_review"
+# SRC_REMARK="Sandwell_et_al.,_2021;_10.1002/essoar.10508279.1"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=elevation
 # SRC_UNIT=m


### PR DESCRIPTION
The submitted paper to the open archive now has a DOI. This ends up in the remark field in the grids, hence this PR.