### PR TITLE
Finalize the srtm_tiles script

### DIFF
--- a/scripts/srv_srtm_coverage.sh
+++ b/scripts/srv_srtm_coverage.sh
@@ -20,7 +20,7 @@ gmt xyz2grd -R-180/180/-60/60 -I1 -r -fg -G/tmp/srtm.nc=nb /tmp/xy.txt -i0-1o0.5
 # 2. Use the @earth_mask_15s_g grid to determine which tiles have at least some ocean in them
 gmt grdmath -R0/360/-60/60 @earth_mask_15s_p 0 EQ = /tmp/ocean_mask.nc=nb
 gmt grd2xyz /tmp/ocean_mask.nc | gmt xyz2grd -R-180/180/-60/60 -I1 -r -Au -G/tmp/ocean.nc=ns -V -fg
-# 3. Combine the tile and 2xocean files to yield the 0,1,2 final grid
-gmt grdmath /tmp/ocean.nc 2 MUL /tmp/srtm.nc ADD = srtm_tiles.nc=nb --IO_NC4_DEFLATION_LEVEL=9
+# 3. Combine the tile and ocean files to yield the 0,1,2 final grid as (ocean & srtm) + srtm:
+gmt grdmath /tmp/ocean.nc /tmp/srtm.nc BITAND /tmp/srtm.nc ADD  = srtm_tiles.nc=nb --IO_NC4_DEFLATION_LEVEL=9
 gmt grdedit srtm_tiles.nc -D+t"Availability of SRTM tiles"+r"0 means empty, 1 means land tile, 2 means partial land tile"
 echo "srtm_tiles.nc: You must manually add it to the cache and commit the change there"


### PR DESCRIPTION
The revised _srv_srtm_coverage.sh_ script seems to work and the plot looks correct.  The point was update the _srtm_tiles.nc_ grid (in the cache) to instead of just having two values (0 = no SRTM, 1 = SRTM) it will have three: (0 = no SRTM, 1 = SRTM land, 2 = SRTM with ocean) so that we know when we need to include the 15s earth_relief filler.  Once I revert 6.3 to do the same as 6.2 regarding determining if we need ocean, then we can test with this new grid.  We need the new tile grid to work for 6.2 and earlier and I think it will since we only checked if the grid was zero or not.  6.3 can then add more checks to distinguish 1 from 2.  So there will be

1. A later PR to this repo that updates the srtm_tiles.nc grid (after testing it).
2. Two PRs to GMT to first reinstall previous behavior then an update to use the fancier tile grid.

![t](https://user-images.githubusercontent.com/26473567/137997411-773382e1-5ed6-47c8-9b04-15d5e16564c8.png)
