### PR TITLE
Really, finalize the srtm coverage script this time

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -16,6 +16,20 @@ in which:
 - *reg* is the grid registration. It can be either **p** (pixel) or **g** (gridline)
 - *suffix* is the grid suffix. It can be *grd* or *tif*.
 
+## Grid and Image domains
+
+All grid and image products shall use longitude range ±180 and not 0-360.
+The recipe files shall deal with any longitude conversions needed.
+Coverage grids (to fill in missing tiles, for instance) shall have the
+same range as the grid it is filling in for.
+
+## Tiles masks
+
+Grids holding information about presence of absence of 1x1 degree tiles
+shall be in 0-360 range format and use gridline-registration so that
+we can check the result using the lower-left integer coordinate of the
+grid cell rather than the center coordinate (off by 0.5) in a pixel grid.
+
 ## Grid registrations
 
 GMT serves up both pixel and gridline registered files if possible.

--- a/scripts/srv_srtm_coverage.sh
+++ b/scripts/srv_srtm_coverage.sh
@@ -1,14 +1,20 @@
 #!/bin/bash -e
 # srv_srtm_coverage.sh - Create the srtm_tiles.nc coverage file for @earth_relief
+#
 # This 1x1 pixel grid helps us know if SRTM tiles are present and if so if it is
 # a partial-ocean tile requiring the filler from @earth_relief_15s.  We want a
-# 1x1 degree pixel grid with: 0 = no SRTM tile, 1 = SRTM tile entirely on land,
-# 2 = SRTM tile with partial ocean.  Since there are no SRTM tiles outside the
+# 1x1 degree pixel grid with: 0 = no SRTM tile, 1 = SRTM tile  with partial ocean,
+# 2 = SRTM tile entirely on land.  Since there are no SRTM tiles outside the
 # 60S/60N latitude band we only need to build the grid for that range.
-# Note: For 6.0-6.2 this was simply a 0 or 1 grid (not 2) and it was a gridline-
-#	registered grid which I think was wrong.  We take the requested w/e/s/n and
-#	round outward to nearest integer degree, so then we should just look at the
-#	tiles inside that region.
+# Note 1: For 6.0-6.2 this was simply a 0 or 1 grid. For 6.3 we have upgraded
+#	that to use 1 (partial) or 2 (full) SRTM coverage, as described above.
+# Note 2: The GMT source code in gmt_remote.c ASSUMES the coverage region is 0/360 so we
+#	are stuck with that even though all the data are -180/180...  This ensures
+#	backwards compatibility so when GMT 6.2 reads the same coverage file it works.
+# Note 3: While the logic here is to use pixel-registration to keep track of the
+#	tiles, backwards compatibility dictates we use gridline-registration and then
+#	use the lower-left corner node to check status for this tile. This creates
+#	a lat = north row with NaNs that we reset to 0 (since outside range anyway).
 #
 # usage: srv_srtm_coverage.sh
 # 
@@ -16,11 +22,18 @@
 #    Since the srtm_tiles.txt file contains N00E006 we need to extract the
 #	lon, lat and add 0.5 for the center of the 1x1 degree pixel
 awk '{ printf "%s%s\t%s\%s\n", substr ($1, 5, 3), substr ($1, 4, 1), substr ($1, 2, 2), substr ($1, 1, 1)}' information/srtm_tiles.txt > /tmp/xy.txt
-gmt xyz2grd -R-180/180/-60/60 -I1 -r -fg -G/tmp/srtm.nc=nb /tmp/xy.txt -i0-1o0.5 -An -V -di0
+gmt xyz2grd -R0/360/-60/60 -I1 -rp -fg -G/tmp/srtm.nc=nb /tmp/xy.txt -i0-1o0.5 -An -V -di0
 # 2. Use the @earth_mask_15s_g grid to determine which tiles have at least some ocean in them
 gmt grdmath -R0/360/-60/60 @earth_mask_15s_p 0 EQ = /tmp/ocean_mask.nc=nb
-gmt grd2xyz /tmp/ocean_mask.nc | gmt xyz2grd -R-180/180/-60/60 -I1 -r -Au -G/tmp/ocean.nc=ns -V -fg
+# Find highest value per 1x1 tile. If 1 then it is partially ocean, else land
+gmt grd2xyz /tmp/ocean_mask.nc | gmt xyz2grd -R0/360/-60/60 -I1 -rp -Au -G/tmp/ocean.nc=ns -V -fg
 # 3. Combine the tile and ocean files to yield the 0,1,2 final grid as (ocean & srtm) + srtm:
-gmt grdmath /tmp/ocean.nc /tmp/srtm.nc BITAND /tmp/srtm.nc ADD  = srtm_tiles.nc=nb --IO_NC4_DEFLATION_LEVEL=9
-gmt grdedit srtm_tiles.nc -D+t"Availability of SRTM tiles"+r"0 means empty, 1 means land tile, 2 means partial land tile"
+gmt grdmath /tmp/srtm.nc 2 MUL /tmp/ocean.nc SUB DUP 0 GE MUL = srtm_tiles_p.nc=nb
+# Then convert to final grid-line registration which will place a row at north with NaNs
+gmt grd2xyz srtm_tiles_p.nc | gmt xyz2grd -R0/360/-60/60 -I1 -rg -fg -G/tmp/tmp.nc=nb -i0-1o-0.5,2
+# Replace the NaNs with 0 since no tiles start at 60N
+gmt grdmath /tmp/tmp.nc=nb 0 DENAN = srtm_tiles.nc=nb --IO_NC4_DEFLATION_LEVEL=9
+# Update the remark and make a test plot of the flags
+gmt grdedit srtm_tiles.nc=nb -D+t"Availability of SRTM tiles"+r"0 means empty, 1 means land tile, 2 means partial land tile"
+gmt grdimage srtm_tiles_p.nc -Cblue,red,lightbrown -B -B+t"SRTM mask ocean (blue), land (brown) and mixed (red)" -png t
 echo "srtm_tiles.nc: You must manually add it to the cache and commit the change there"


### PR DESCRIPTION
Learned that the coverage _srtm_tiles.nc_ grid must be gridline registered due to how GMT uses it so we must stay backwards compatible and keep that registration.  Documented this better both in MAINTENANCE.md file s well as the reasoning in the _srv_srtm_coverage.sh_ script.  Also decided that it made more sense to use 0 = no tile, 1 = partial tile, 2 = full tile.