### PR TITLE
SHorten the remarks in the grids

### DIFF
--- a/recipes/earth_faa.recipe
+++ b/recipes/earth_faa.recipe
@@ -12,7 +12,7 @@
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/grav_31.1.nc
 # SRC_TITLE=Earth_Free_Air_Gravity_Anomalies_v31
-# SRC_REMARK="Sandwell_et_al.,_2019;_https://doi.org/10.1016/j.asr.2019.09.011,_Pavlis_et_al.,_2012;_https://doi.org/10.1029/2011JB008916"
+# SRC_REMARK="Sandwell_et_al.,_2019;_https://doi.org/10.1016/j.asr.2019.09.011"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=faa
 # SRC_UNIT=mGal

--- a/recipes/earth_vgg.recipe
+++ b/recipes/earth_vgg.recipe
@@ -12,7 +12,7 @@
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/curv_31.1.nc
 # SRC_TITLE=Earth_Vertical_Gravity_Gradient_Anomalies_v31
-# SRC_REMARK="Sandwell_et_al.,_2019;_https://doi.org/10.1016/j.asr.2019.09.011,_Pavlis_et_al.,_2012;_https://doi.org/10.1029/2011JB008916"
+# SRC_REMARK="Sandwell_et_al.,_2019;_https://doi.org/10.1016/j.asr.2019.09.011"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=vgg
 # SRC_UNIT=Eotvos


### PR DESCRIPTION
Related to GMT issue https://github.com/GenericMappingTools/gmt/issues/6078.  Since the documentation will spell out the Pavlis et al. reference I think it is OK for now to only use the Sandwell et al citation in the netCDF grids.