### PR TITLE
Ensure global grids are -180/180 in longitude

### DIFF
--- a/recipes/earth_geoid.recipe
+++ b/recipes/earth_geoid.recipe
@@ -2,7 +2,7 @@
 # 2021-10-15 PW
 #
 # We use a precision of 0.01 m
-# I am using the EGM2008.grd 1x1 arc minute grid on Wessel ftp dir at SEOST, built from NGA source files.
+# I am using the EGM2008.grd 1x1 arc minute grid on Wessel ftp dir at SOEST, built from NGA source files.
 # The range of -106.910003662 to +85.8389968872 m means we may use offset of 0 and scale of 0.01
 #
 # To be given as input file to script srv_downsampler_grid.sh

--- a/recipes/earth_mag.recipe
+++ b/recipes/earth_mag.recipe
@@ -15,7 +15,7 @@
 # SRC_UNIT=nT
 # As source is an ASCII grid we add conversion commands (separated by ;) and original file extension
 # SRC_PROCESS="rm -f EMAG2_V3_20170530.nc; unzip -n EMAG2_V3_20170530.zip"
-# SRC_CUSTOM="gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,4 -Rg -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
+# SRC_CUSTOM="gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,4 -Rd -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
 # SRC_EXT=csv
 #
 # Destination: Specify output node registration, file prefix, and netCDF format

--- a/recipes/earth_mag4km.recipe
+++ b/recipes/earth_mag4km.recipe
@@ -15,7 +15,7 @@
 # SRC_UNIT=nT
 # As source is an ASCII grid we add conversion commands (separated by ;) and original file extension
 # SRC_PROCESS="rm -f EMAG2_V3_20170530.nc; unzip -n EMAG2_V3_20170530.zip"
-# SRC_CUSTOM="gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,5 -Rg -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
+# SRC_CUSTOM="gmt xyz2grd EMAG2_V3_20170530.csv -i2,3,5 -Rd -I2m -rp -fg -GEMAG2_V3_20170530.nc -di99999"
 # SRC_EXT=csv
 #
 # Destination: Specify output node registration, file prefix, and netCDF format


### PR DESCRIPTION
Both the two EMAG grid recipes had **-Rg** instead of **-Rd**, and when I built the EGM original grid I also used **-Rg**... This lead to wrong tile names.  I have updated the EGM2008.nc "source" grid on the SOEST ftp. Tiles will be rebuilt soon.