### PR TITLE
Minor issues fixed in recipes and script

### DIFF
--- a/recipes/earth_faa.recipe
+++ b/recipes/earth_faa.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering Sandwell FAA gravity grid with EGM2008 on land
-# 2021-10-06 PW
+# 2022-01-12 PW
 #
 # We use a precision of 0.025 mGal
 # This is based on the raw data file for version 31.
@@ -11,7 +11,7 @@
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/grav_31.1.nc
-# SRC_TITLE=IGPP_Earth_Free_Air_Gravity_Anomalies
+# SRC_TITLE=IGPP_Earth_Free_Air_Gravity_Anomalies_v31
 # SRC_REMARK="Sandwell_et_al.,_2019;_https://doi.org/10.1016/j.asr.2019.09.011"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=faa

--- a/recipes/earth_gebco.recipe
+++ b/recipes/earth_gebco.recipe
@@ -11,7 +11,7 @@
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://ftp.soest.hawaii.edu/pwessel/GEBCO/GEBCO_2021.nc
 # SRC_TITLE=GEBCO_Earth_Relief
-# SRC_REMARK="GEBCO_Compilation_Group,_2020_GEBCO_2021_Grid;_https://doi.org/10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f"
+# SRC_REMARK="GEBCO_Compilation_Group,_2021_GEBCO_2021_Grid;_https://doi.org/10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=elevation
 # SRC_UNIT=m

--- a/recipes/earth_gebcosi.recipe
+++ b/recipes/earth_gebcosi.recipe
@@ -11,7 +11,7 @@
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://ftp.soest.hawaii.edu/pwessel/GEBCO/GEBCO_2021_sub_ice_topo.nc 
 # SRC_TITLE=GEBCO_Sub-Ice_Earth_Relief
-# SRC_REMARK="GEBCO_Compilation_Group,_2020_GEBCO_2021_Grid;_https://doi.org/10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f"
+# SRC_REMARK="GEBCO_Compilation_Group,_2021_GEBCO_2021_Grid;_https://doi.org/10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=elevation
 # SRC_UNIT=m

--- a/recipes/earth_vgg.recipe
+++ b/recipes/earth_vgg.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering Sandwell VGG grid with EGM2008 on land
-# 2021-10-06 PW
+# 2022-01-12 PW
 #
 # We use a precision of 0.03125 Eotvos
 # This is based on the raw data file for version 31.
@@ -11,7 +11,7 @@
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
 # SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/curv_31.1.nc
-# SRC_TITLE=IGPP_Earth_Vertical_Gravity_Gradient_Anomalies
+# SRC_TITLE=IGPP_Earth_Vertical_Gravity_Gradient_Anomalies_v31
 # SRC_REMARK="Sandwell_et_al.,_2019;_https://doi.org/10.1016/j.asr.2019.09.011"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=vgg

--- a/scripts/srv_downsampler_grid.sh
+++ b/scripts/srv_downsampler_grid.sh
@@ -102,8 +102,8 @@ fi
 y_range=$(gmt grdinfo ${SRC_FILE} -Cn -o2-3 | awk '{print $2 - $1}')
 if [ ${y_range} -lt 180 ]; then
 	x_range=$(gmt grdinfo ${SRC_FILE} -Cn -o0-1 | awk '{printf "%s/%s\n", $1, $2}')
-	gmt grdcut ${SRC_FILE} -R${x_range}/-90/90 -G${TMP}/extend.grd -N -V
-	SRC_FILE=${TMP}/extend.grd
+	gmt grdcut ${SRC_FILE} -R${x_range}/-90/90 -G${TMP}/${SRC_FILE} -N -V
+	SRC_FILE=${TMP}/${SRC_FILE}
 fi
 
 # 7. Extract the requested resolutions and registrations


### PR DESCRIPTION
Fixes GEBCO year, adds Sandwell versions, and uses more descriptive name for temp grid. We will wait a day or two to see if the Brits will update the wrong DOI for gebco.