### PR TITLE
Bypass 30s filtering issue via hemisphere solution

### DIFF
--- a/scripts/srv_downsampler_grid.sh
+++ b/scripts/srv_downsampler_grid.sh
@@ -178,8 +178,8 @@ while read RES UNIT DST_TILE_SIZE CHUNK MASTER; do
 			gmt grdfilter -R-180/180/0/90  ${SRC_FILE} -Fg${FILTER_WIDTH} -D${FMODE} -I${RES}${UNIT} -r${REG} -G${TMP}/n.grd --PROJ_ELLIPSOID=Sphere
 			gmt grdpaste ${TMP}/s.grd ${TMP}/n.grd -G${TMP}/both.grd
 			remark="Reduced by Gaussian ${DST_MODE} filtering (${FILTER_WIDTH} km fullwidth) from ${SRC_FILE/+/\\+} [${REMARK}]"
-			gmt grdedit ${TMP}/both.grd -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
 			gmt grdconvert ${TMP}/both.grd -G${DST_FILE}=${DST_MODIFY} --IO_NC4_DEFLATION_LEVEL=9 --IO_NC4_CHUNK_SIZE=${CHUNK} 			
+			gmt grdedit ${DST_FILE} -D+t"${grdtitle}"+r"${remark}"+z"${SRC_NAME} (${SRC_UNIT})"
 		else	# Must down-sample to a lower resolution via spherical Gaussian filtering
 			# Get suitable Gaussian full-width filter rounded to nearest 0.1 km after adding 50 meters for noise
 			echo "Down-filter ${SRC_FILE} to ${DST_FILE}=${DST_MODIFY}"


### PR DESCRIPTION
See this [issue](https://github.com/GenericMappingTools/remote-datasets/issues/32) for background. This PR implements that solution in order to bypass a bug in **grdfilter** that shows up for these very large datasets.