### PR TITLE
Add recipe for moon DEM

### DIFF
--- a/recipes/moon_relief.recipe
+++ b/recipes/moon_relief.recipe
@@ -1,0 +1,45 @@
+# Recipe file for down-filtering LOLA
+# 2023-01-03 PW
+#
+# We use a precision of 0.5 m with a zero offset to fit the range of -9128.5 to 10781.5 in 16-bit ints
+
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=https://planetarymaps.usgs.gov/mosaic/Lunar_LRO_LOLA_Global_LDEM_118m_Mar2014.tif
+# SRC_TITLE=LOLA_Moon_Relief
+# SRC_REF="Mazarico_et_al.,_2013"
+# SRC_DOI="https://doi.org/10.1007/s00190-011-0509-4"
+# SRC_RADIUS=1737.400
+# SRC_NAME=elevation
+# SRC_UNIT=m
+# SRC_CUSTOM="gmt grdedit Lunar_LRO_LOLA_Global_LDEM_118m_Mar2014.tif -Rd -fg -GLunar_LRO_LOLA_Global_LDEM_118m_Mar2014.nc"
+# SRC_EXT=tif
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=moon
+# DST_PREFIX=moon_relief
+# DST_FORMAT=ns
+# DST_SCALE=0.5
+# DST_OFFSET=0
+# DST_CPT=geo
+# DST_SRTM=no
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+14		s		10		4096	master
+15		s		10		4096
+30		s		15		4096
+01		m		30		4096
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		2048
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/scripts/srv_downsampler_grid.sh
+++ b/scripts/srv_downsampler_grid.sh
@@ -30,7 +30,8 @@ else
 	echo "error: Run srv_downsampler_grid.sh from scripts folder or top gmtserver-admin directory"
 	exit -1
 fi
-# 1. Move into the staging directory
+# 1. Move into the staging directory, possibly after creating it
+mkdir -p ${TOPDIR}/staging
 cd ${TOPDIR}/staging
 	
 # 2. Get recipe full file path


### PR DESCRIPTION
See discussion on #167.  This is a draft recipe file plus changes needed for the downsampler script to use proper projection ellipsoid for the moon, and a generalization to work around unsolved bug in **grdfilter** for 30s or less output grids. It basically seems to work with a few caveats:

- Since starting grid is ~8Gb and GMT just reads that in, anyone attempting to work with these files probably need at least 16 Gb RAM. I have 64 Gb so not noticing such issues...
- The current recipe makes both the master 14s grid (which is just reformatting) and then it starts building new global grids from 15s up.  We may discuss if we want a 15s grid since 14s is the original and better while the 15s will be filtered and much smoother than if the original data had been processed to be 15s instead of 14s.  I suspect NASA picked 256 pixels per degree for other reasons than that is the optimum resolution, so there we are.  I am open to just having the 14s versions (so 14s, 30s, 01m etc and no 15s) but build in a scheme where `@moon_relief_15s` requests would return 14s instead (with a warning).
- The current script runs for me (especially after a [macOS](https://github.com/GenericMappingTools/gmt/pull/7189) fix in GMT).
- The downsample script was modified to handle the different ellipsoid (moon vs sphere) and I generalised the section that bypasses the **grdfilter** 64-bit bug for output grids <= 30 arc second (since I am building both 15s and 30s at the moment)
- There does not seem to be a need for similar upgrades to the tiler script which we run once all the global grids are made - it then breaks the larger grids into tons of JP2 tiles - but we will find out when we get there.
- Happy to entertain ideas what the default CPT for the moon should be. It is set to geo right now.  We have no `@moon_relief.cpt` I think so we would have to make one if we want that. Note the name of the CPT will go into the gmt_data_server.txt file and the file itself is cache.

To run this (if RAM requirement is satisfied) is to first get the gmtserver-admin repo, then navigate to that top dir and run

`scripts/srv_downsampler_grid.sh moon_relief`

Here is what the 01m plot looks like - I killed things before we did everything:

`gmt grdimage moon_relief_01m_g.grd -B -png t`

![t](https://user-images.githubusercontent.com/26473567/210385261-e11637ba-c85a-44ca-82f2-727135b91678.png)
