### PR TITLE
Add draft recipes for Mercury, Mars, Venus, and Pluto

### DIFF
--- a/recipes/mars_relief.recipe
+++ b/recipes/mars_relief.recipe
@@ -1,0 +1,45 @@
+# Recipe file for down-filtering OLA
+# 2023-01-07 PW
+#
+# We use a precision of 0.5 m with a 6000 m offset to fit the range of -8528 to +21226 in 16-bit ints
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=https://planetarymaps.usgs.gov/mosaic/Mars/HRSC_MOLA_Blend/Mars_HRSC_MOLA_BlendDEM_Global_200mp_v2.tif
+# SRC_TITLE=LOLA_Moon_Relief
+# SRC_REF="Neumann_et_al.,_2003"
+# SRC_DOI="https://doi.org/10.1029/2000JE001426/abstract"
+# SRC_RADIUS=3396.190
+# SRC_NAME=elevation
+# SRC_UNIT=m
+# SRC_CUSTOM="gmt grdedit Mars_HRSC_MOLA_BlendDEM_Global_200mp_v2.tif -Rd -fg -GMars_HRSC_MOLA_BlendDEM_Global_200mp_v2.nc"
+# SRC_EXT=tif
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=mars
+# DST_PREFIX=mars_relief
+# DST_FORMAT=ns
+# DST_SCALE=0.5
+# DST_OFFSET=6000
+# DST_CPT=@mars_relief.cpt
+# DST_SRTM=no
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+12		s		10		4096	master
+15		s		10		4096
+30		s		15		4096
+01		m		30		4096
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		2048
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/recipes/mercury_relief.recipe
+++ b/recipes/mercury_relief.recipe
@@ -1,0 +1,43 @@
+# Recipe file for down-filtering Messenger
+# 2023-01-07 PW
+#
+# We use a precision of 0.5 m with a zero offset to fit the range of -9128.5 to 10781.5 in 16-bit ints
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=https://planetarymaps.usgs.gov/mosaic/Mercury_Messenger_USGS_DEM_Global_665m_v2.tif
+# SRC_TITLE=Messenger_Mercury_Relief
+# SRC_REF="Becker_et_al.,_2016"
+# SRC_DOI="https://www.hou.usra.edu/meetings/lpsc2016/pdf/2959.pdf"
+# SRC_RADIUS=2439.400
+# SRC_NAME=elevation
+# SRC_UNIT=m
+# SRC_CUSTOM="gmt grdedit Mercury_Messenger_USGS_DEM_Global_665m_v2.tif -Rd -fg -GMercury_Messenger_USGS_DEM_Global_665m_v2.nc"
+# SRC_EXT=tif
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=mercury
+# DST_PREFIX=mercury_relief
+# DST_FORMAT=ns
+# DST_SCALE=0.5
+# DST_OFFSET=0
+# DST_CPT=@mercury_relief.cpt
+# DST_SRTM=no
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+56		s		30		4096	master
+01		m		30		4096
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		2048
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/recipes/pluto_relief.recipe
+++ b/recipes/pluto_relief.recipe
@@ -1,0 +1,43 @@
+# Recipe file for down-filtering New Horizon
+# 2023-01-07 PW
+#
+# We use a precision of 0.25 m with a 1000 m offset to fit the range of -4101 to +6491 in 16-bit ints
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=https://planetarymaps.usgs.gov/mosaic/Pluto_NewHorizons_Global_DEM_300m_Jul2017_16bit.tif
+# SRC_TITLE=LOLA_Moon_Relief
+# SRC_REF="Moore_et_al.,_2016"
+# SRC_DOI="https://doi.org/10.1126/science.aad7055"
+# SRC_RADIUS=1188.300
+# SRC_NAME=elevation
+# SRC_UNIT=m
+# SRC_CUSTOM="gmt grdedit Pluto_NewHorizons_Global_DEM_300m_Jul2017_16bit.tif -Rd -fg -GPluto_NewHorizons_Global_DEM_300m_Jul2017_16bit.nc"
+# SRC_EXT=tif
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=pluto
+# DST_PREFIX=pluto_relief
+# DST_FORMAT=ns
+# DST_SCALE=0.25
+# DST_OFFSET=1000
+# DST_CPT=@pluto_relief.cpt
+# DST_SRTM=no
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+52		s		15		4096	master
+01		m		30		4096
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		2048
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/recipes/venus_relief.recipe
+++ b/recipes/venus_relief.recipe
@@ -1,0 +1,34 @@
+# Recipe file for down-filtering Magellan
+# 2023-01-07 PW
+#
+# We use a precision of 0.5 m with a 4000 m offset to fit the range of -2951 to 11687 in 16-bit ints
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=https://planetarymaps.usgs.gov/mosaic/Venus_Magellan_Topography_Global_4641m_v02.tif
+# SRC_TITLE=Magellan_Venus_Relief
+# SRC_REF="Ford_et_al.,_1991"
+# SRC_DOI="https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19940013181.pdf"
+# SRC_RADIUS=6051.000
+# SRC_NAME=elevation
+# SRC_UNIT=m
+# SRC_CUSTOM="gmt grdedit Venus_Magellan_Topography_Global_4641m_v02.tif -Rd -fg -GVenus_Magellan_Topography_Global_4641m_v02.nc"
+# SRC_EXT=tif
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=venus
+# DST_PREFIX=venus_relief
+# DST_FORMAT=ns
+# DST_SCALE=0.5
+# DST_OFFSET=4000
+# DST_CPT=@venus_relief.cpt
+# DST_SRTM=no
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+23		m		0		4096	master
+30		m		0		4096
+01		d		0		4096


### PR DESCRIPTION
All based off the recipe for the Moon since all are TIFFs. There may be some minor adjustments needed as we actually try to build the collections.  Here are a few related questions:

- NASA likes to do things like "N pixels per degree".  So of N = 64 then the grid spacing is 56.25 arc seconds.  This does not fit very well with our 1, 3, 10, 15, 30, .... naming scheme.  Of course, the very first downsampling can become one of those, in this case 01m and then up.  But I dont like to name things like `@mercury_relief_56.25s_g|p`, for instance (and the **gmt** code decoding from strings will need to check for these decimalized numbers).  One option would be to use a special flag for "the highest resolution", say, `@mercury_relief_full_g|p` so the users would not need to know what that resolution is.  Of course, if you just say `@mercury_relief` in **grdimage** or similar then you get the best resolution needed to make the map at the default DPI (**GMT_GRAPHICS_DPU**) but if you want to do **grdmath** or request the full resolution then you need to specify that.
- GMT has ellipsoids (i.e., spheroids) for the planets, but they all say 2000 (official values at that time).  I notice there are discrepancies between those values and the radii listed on the NASA site for the various data sets.  We use those radii to convert filter widths in km to spherical angles for that planet, so that works well.  But then, if you are to make maps of Pluto in GMT you need to do **--PROJ_ELLIPSOID**=_pluto_ and then there is a tiny mismatch between the two radii.  Not sure if this is important.  But while we have > 50 ellipsoids for the Earth, we only have one each for the planets.  Do we add pluto-NH (New Horizon), mercury-M (Messenger), Moon-L (LOLA) etc.?

I think it makes sense to add all these terrestrial planets at the same time and not just do the moon.

Comments, please.