### PR TITLE
Optimize planetry recipes for keeping highest resolutions

### DIFF
--- a/recipes/mars_relief.recipe
+++ b/recipes/mars_relief.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering MOLA
-# 2023-01-07 PW
+# 2023-01-09 PW
 #
 # We use a precision of 0.5 m with a 6000 m offset to fit the range of -8528 to +21226 in 16-bit ints
 #
@@ -28,8 +28,9 @@
 # DST_SRTM=no
 #
 # List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# Given dimension  106694 x 53347 we have spacing of 12.1468873601 arc seconds as master and 14x7 tiles
 # res	unit	tile	chunk	code
-12		s		10		4096	master
+12.1468873601	s		25.7142857143		4096	master
 15		s		10		4096
 30		s		15		4096
 01		m		30		4096

--- a/recipes/mercury_relief.recipe
+++ b/recipes/mercury_relief.recipe
@@ -28,8 +28,9 @@
 # DST_SRTM=no
 #
 # List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# Given dimension  23040 x 11520 we have spacing of 56.25 arc seconds as master and 12x6 tiles
 # res	unit	tile	chunk	code
-56		s		30		4096	master
+56.25	s		30		4096	master
 01		m		30		4096
 02		m		60		4096
 03		m		90		2048

--- a/recipes/mercury_relief.recipe
+++ b/recipes/mercury_relief.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering Messenger
-# 2023-01-07 PW
+# 2023-01-09 PW
 #
 # We use a precision of 0.5 m with a zero offset to fit the range of -9128.5 to 10781.5 in 16-bit ints
 #

--- a/recipes/moon_relief.recipe
+++ b/recipes/moon_relief.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering LOLA
-# 2023-01-03 PW
+# 2023-01-09 PW
 #
 # We use a precision of 0.5 m with a zero offset to fit the range of -9128.5 to 10781.5 in 16-bit ints
 #
@@ -28,8 +28,9 @@
 # DST_SRTM=no
 #
 # List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# Given dimension  92160 x 46080 we have spacing of 114.0625 arc seconds as master and 36x18 tiles
 # res	unit	tile	chunk	code
-14		s		10		4096	master
+14.0625	s		10		4096	master
 15		s		10		4096
 30		s		15		4096
 01		m		30		4096

--- a/recipes/pluto_relief.recipe
+++ b/recipes/pluto_relief.recipe
@@ -28,8 +28,9 @@
 # DST_SRTM=no
 #
 # List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# Given dimension  24888 x 12444 we have spacing of 52.07... arc seconds as master and 12x6 tiles
 # res	unit	tile	chunk	code
-52		s		15		4096	master
+52.0732883317		s		30		4096	master
 01		m		30		4096
 02		m		60		4096
 03		m		90		2048

--- a/recipes/pluto_relief.recipe
+++ b/recipes/pluto_relief.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering New Horizon
-# 2023-01-07 PW
+# 2023-01-09 PW
 #
 # We use a precision of 0.25 m with a 1000 m offset to fit the range of -4101 to +6491 in 16-bit ints
 #

--- a/recipes/venus_relief.recipe
+++ b/recipes/venus_relief.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering Magellan
-# 2023-01-07 PW
+# 2023-01-09 PW
 #
 # We use a precision of 0.5 m with a 4000 m offset to fit the range of -2951 to 11687 in 16-bit ints
 #
@@ -28,7 +28,15 @@
 # DST_SRTM=no
 #
 # List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# Given dimension  8192 x 4096 we have spacing of 2.63... arc minutes as master and 6x4 tiles
 # res	unit	tile	chunk	code
-23		m		0		4096	master
+2.63671875		m		60		4096	master
+03		m		90		2048
+04		m		180		2048
+05		m		180		2048
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
 30		m		0		4096
 01		d		0		4096

--- a/scripts/get_prefix_func.sh
+++ b/scripts/get_prefix_func.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
-# Function that creates tile label
+# Function that creates tile label in integer degrees W/S
 
 function get_prefix  () {       # Takes west (in -180/180 range) and south and makes the {N|S}yy{W|E}xxx prefix
-	if [ $1 -ge 0 ]; then
-		X=$(printf "E%03d" $1)
+	# Get nearest integer degrees
+	W=$(gmt math -Q $1 RINT =)
+	S=$(gmt math -Q $2 RINT =)
+	if [ $W -ge 0 ]; then
+		X=$(printf "E%03d" $W)
 	else
-		t=$(gmt math -Q $1 NEG =)
+		t=$(gmt math -Q $W NEG =)
 		X=$(printf "W%03d" $t)
 	fi
-	if [ $2 -ge 0 ]; then
-		Y=$(printf "N%02d" $2)
+	if [ $S -ge 0 ]; then
+		Y=$(printf "N%02d" $S)
 	else
-		t=$(gmt math -Q $2 NEG =)
+		t=$(gmt math -Q $S NEG =)
 		Y=$(printf "S%02d" $t)
 	fi
 	echo ${Y}${X}

--- a/scripts/srv_downsampler_image.sh
+++ b/scripts/srv_downsampler_image.sh
@@ -10,6 +10,13 @@
 # format, radius of the planetary body, desired node registration and resolutions,
 # name prefix, and filter type, etc.  Thus, this script should handle images from
 # different planets.
+# Note: If the highest resolution image is not an integer unit then some exploration
+# needs to be done to determine what increment and tile size give an integer number
+# of tiles over 360 and 180 ranges.  E.g., below is the master line for mars_relief
+# (which had 200 m pixels on Mars spheroid) and earth_relief (which as 15s exactly):
+#	12.1468873601	s		25.7142857143		4096	master
+#	15				s		10					4096	master
+# Easiest to work with number of rows and find suitable common factors.
 
 if [ $# -eq 0 ]; then
 	echo "usage: srv_downsampler_image.sh recipefile"
@@ -102,10 +109,11 @@ while read RES UNIT TILE MASTER; do
 		echo "Bad resolution $RES - aborting"
 		exit -1
 	fi
-	if [ ! ${RES} = "01" ]; then	# Use plural unit
+	IRES=$(gmt math -Q ${RES} FLOOR =)
+	if [ ${IRES} -gt 1 ]; then	# Use plural unit
 		UNIT_NAME="${UNIT_NAME}s"
 	fi
-	DST_FILE=${DST_PLANET}/${DST_PREFIX}/${DST_PREFIX}_${RES}${UNIT}.tif
+	DST_FILE=${DST_PLANET}/${DST_PREFIX}/${DST_PREFIX}_${IRES}${UNIT}.tif
 	if [ -f ${DST_FILE} ]; then	# Do nothing
 		echo "${DST_FILE} exist - skipping"
 	elif [ "X${MASTER}" = "Xmaster" ]; then # Just make a copy of the master to a new output file


### PR DESCRIPTION
See #171 for background.  I have solved the issue by determining the exact increment and tile size required for the highest resolution, which gets a name based on the floor of the actual increment.  Need floor since 2.56 cannot be rint to 3 since we also will make a 03m grid. Testing this now but seems to work so want to get these into the repo for further testing.