### PR TITLE
Make sure rounded resolution has 2 digits

### DIFF
--- a/scripts/srv_downsampler_grid.sh
+++ b/scripts/srv_downsampler_grid.sh
@@ -172,6 +172,7 @@ while read RES UNIT DST_TILE_SIZE CHUNK MASTER; do
 	if [ ${IRES} -gt 1 ]; then	# Use plural unit
 		UNIT_NAME="${UNIT_NAME}s"
 	fi
+	IRES=$(gmt math -Q ${RES} FLOOR = --FORMAT_FLOAT_OUT=%02.0f)
 	for REG in ${DST_NODES}; do # Probably doing both pixel and gridline registered output, except for master */
 		DST_FILE=${DST_PLANET}/${DST_PREFIX}/${DST_PREFIX}_${IRES}${UNIT}_${REG}.grd
 		grdtitle="${TITLE} at ${RES} arc ${UNIT_NAME}"

--- a/scripts/srv_tiler.sh
+++ b/scripts/srv_tiler.sh
@@ -118,7 +118,7 @@ while read RES UNIT DST_TILE_SIZE CHUNK MASTER ; do
 	fi
 	for REG in ${DST_NODES}; do # Probably doing both pixel and gridline registered output, except for master */
 		# Name and path of grid we wish to tile
-		IRES=$(gmt math -Q ${RES} FLOOR =)
+		IRES=$(gmt math -Q ${RES} FLOOR = --FORMAT_FLOAT_OUT=%02.0f)
 		DST_TILE_TAG=${DST_PREFIX}_${IRES}${UNIT}_${REG}
 		DST_FILE=${DST_TILE_TAG}.grd
 		if [ -f ${DATADIR}/${DST_FILE} ]; then # found locally


### PR DESCRIPTION
When the original data set has an odd resolution like 52.074555234s we floor that to get 52.  However, that code would turn 2.45666 into 2 but we need 02.

This PR set s the required format so that we get a 2-digit resolution value.  With that it looks like the scripts and recipes works for the new candidates Moon, Mercury, Mars, Venus, and Pluto.