### PR TITLE
Update server-info in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 #	Makefile for gmtserver-admin
 #
 #
-#	Author:	Paul Wessel, SOEST, U. of Hawaii
+#	Author:	Paul Wessel, SOEST, U. of Hawaii.
 #
-#	Update Date:	15-JAN-2022
+#	Update Date:	02-FEB-2023
 #
 #-------------------------------------------------------------------------------
 #	!! STOP EDITING HERE, THE REST IS FIXED !!
@@ -22,9 +22,11 @@ help::
 
 server-info:
 		date "+%Y-%m-%d" | awk '{printf "s/THEDATE/%s/g\n", $$1}' > /tmp/sed.txt
-		cat information/earth_*_server.txt | grep -v '^#' | wc -l | awk '{printf "%d\n", $$1}' > information/gmt_data_server.txt
-		sed -f /tmp/sed.txt < information/gmt_data_server_header.txt >> information/gmt_data_server.txt
-		cat information/earth_*_server.txt >> information/gmt_data_server.txt
+		rm information/gmt_data_server.txt
+		cat information/*_*_server.txt | grep -v '^#' | wc -l | awk '{printf "%d\n", $$1}' > /tmp/gmt_data_server.txt
+		sed -f /tmp/sed.txt < information/gmt_data_server_header.txt >> /tmp/gmt_data_server.txt
+		cat information/*_*_server.txt >> /tmp/gmt_data_server.txt
+		mv /tmp/gmt_data_server.txt information/gmt_data_server.txt  
 
 earth-topo:
 		make earth-relief


### PR DESCRIPTION
See details in #178. The idea is to update the server-info section of Makefile.

I replace earth_*_server.txt for *_*_server.txt. The problem with this is that reads the gmt_data_server.txt file.  To avoid this, first I remove the file. Then, I save the file in the temporal folder (/tmp/) . Finally, I move the file to the information folder.

With these changes, I think that will get a gmt_data_server.txt for any type cellestial body (earth, moon, mars, etc).