### PR TITLE
Handle cache updates from oceania to the ghost servers

### DIFF
--- a/scripts/srv_do_updates.sh
+++ b/scripts/srv_do_updates.sh
@@ -19,3 +19,8 @@ bash scripts/srv_update_sha256.sh
 cp -f ../data/gmt_hash_server.txt ../data/gmt_md5_server.txt
 # 1f Place a copy of the data information table in the data dir with leading record indicating number of item
 cp -f information/gmt_data_server.txt  ../data
+# 1g Also do rsync of files than may have changed to {candidate,static,test}, including cache dir
+for ghost_server in candidate static test; do
+	rsync -a --delete cache ../${ghost_server}
+	cp -f ../data/gmt_hash_server.txt ../${ghost_server}
+done


### PR DESCRIPTION
Every hour a cron job on _oceania_ runs to see if `gmtserver-admin` has updates.  After updating _oceania_, this script `rsyncs` the _cache_ directory to the three ghost servers (candidate, static, test). This means all four server cache directories are always updated, whereas remote data sets must go manually via makefiles and scripts.

**Note**: None of this affects the mirrors which only `rsync` _oceania_.