### PR TITLE
Add deflection of vertical and gravity errors recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ earth-topo:
 earth-grav:
 		make earth-faa
 		make earth-vgg
+		make earth-edefl
+		make earth-ndefl
+		make earth-faaerror
 
 earth-mag:
 		make earth-emag
@@ -127,6 +130,18 @@ earth-faa:
 earth-vgg:
 		scripts/srv_downsampler.sh earth_vgg
 		scripts/srv_tiler.sh earth_vgg
+
+earth-edefl:
+		scripts/srv_downsampler.sh earth_edefl
+		scripts/srv_tiler.sh earth_edefl
+
+earth-ndefl:
+		scripts/srv_downsampler.sh earth_ndefl
+		scripts/srv_tiler.sh earth_ndefl
+
+earth-faaerror:
+		scripts/srv_downsampler.sh earth_faaerror
+		scripts/srv_tiler.sh earth_faaerror
 
 earth-wdmam:
 		scripts/srv_downsampler.sh earth_wdmam

--- a/recipes/earth_edefl.recipe
+++ b/recipes/earth_edefl.recipe
@@ -1,0 +1,44 @@
+# Recipe file for down-filtering Sandwell east deflection grid with EGM2008 on land
+# 2023-09-21 PW
+#
+# We use a precision of 0.03125 microradians
+# This is based on the raw data file for version 32.
+# The range of -406.305541992 to +427.036224365 microradians means we may use offset of -10 and scale of 0.03125
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.03125 = 1/32)
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/east_32.1.nc
+# SRC_TITLE=IGPP_Earth_East_Deflection_of_the_Vertical_v32
+# SRC_REF="Sandwell_et_al.,_2019"
+# SRC_DOI="https://doi.org/10.1016/j.asr.2019.09.011"
+# SRC_RADIUS=6371.0087714
+# SRC_NAME=edefl
+# SRC_UNIT=microradians
+#
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=earth
+# DST_PREFIX=earth_edefl
+# DST_FORMAT=ns
+# DST_SCALE=0.04
+# DST_OFFSET=-50
+# DST_CPT=@earth_defl.cpt
+# DST_SRTM=no
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+01		m		30		4096	master
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		1024
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/recipes/earth_faaerrors.recipe
+++ b/recipes/earth_faaerrors.recipe
@@ -15,18 +15,18 @@
 # SRC_REF="Sandwell_et_al.,_2019"
 # SRC_DOI="https://doi.org/10.1016/j.asr.2019.09.011"
 # SRC_RADIUS=6371.0087714
-# SRC_NAME=faaerrors
+# SRC_NAME=faaerror
 # SRC_UNIT=mGal
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
 # DST_NODES=g,p
 # DST_PLANET=earth
-# DST_PREFIX=earth_faaerrors
+# DST_PREFIX=earth_faaerror
 # DST_FORMAT=ns
 # DST_SCALE=0.04
 # DST_OFFSET=-50
-# DST_CPT=@earth_faaerrors.cpt
+# DST_CPT=@earth_faaerror.cpt
 # DST_SRTM=no
 #
 # List of desired output resolution and chunk size.  Flag the source resolution with code == master

--- a/recipes/earth_faaerrors.recipe
+++ b/recipes/earth_faaerrors.recipe
@@ -1,0 +1,44 @@
+# Recipe file for down-filtering Sandwell FAA error grid with EGM2008 on land
+# 2023-09-21 PW
+#
+# We use a precision of 0.03125 microradians
+# This is based on the raw data file for version 32.
+# The range of -7.80630970001 to +58.244110107 mGal means we may use offset of 25 and scale of 0.005
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.005 = 1/200)
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/grav_error_32.1.nc
+# SRC_TITLE=IGPP_Earth_Free_Air_Gravity_Anomaly_Errors_v32
+# SRC_REF="Sandwell_et_al.,_2019"
+# SRC_DOI="https://doi.org/10.1016/j.asr.2019.09.011"
+# SRC_RADIUS=6371.0087714
+# SRC_NAME=faaerrors
+# SRC_UNIT=mGal
+#
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=earth
+# DST_PREFIX=earth_faaerrors
+# DST_FORMAT=ns
+# DST_SCALE=0.04
+# DST_OFFSET=-50
+# DST_CPT=@earth_faaerrors.cpt
+# DST_SRTM=no
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+01		m		30		4096	master
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		1024
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096

--- a/recipes/earth_ndefl.recipe
+++ b/recipes/earth_ndefl.recipe
@@ -1,0 +1,44 @@
+# Recipe file for down-filtering Sandwell north deflection grid with EGM2008 on land
+# 2023-09-21 PW
+#
+# We use a precision of 0.03125 microradians
+# This is based on the raw data file for version 32.
+# The range of -570.314331055 to +484.914001465 microradians means we may use offset of -50 and scale of 0.04
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.04 = 1/25)
+#
+# To be given as input file to script srv_downsampler_grid.sh
+#
+# Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
+#	name of z-variable, and z unit.
+# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/north_32.1.nc
+# SRC_TITLE=IGPP_Earth_North_Deflection_of_the_Vertical_v32
+# SRC_REF="Sandwell_et_al.,_2019"
+# SRC_DOI="https://doi.org/10.1016/j.asr.2019.09.011"
+# SRC_RADIUS=6371.0087714
+# SRC_NAME=ndefl
+# SRC_UNIT=microradians
+#
+# Destination: Specify output node registration, file prefix, and netCDF format
+# DST_MODE=Cartesian
+# DST_NODES=g,p
+# DST_PLANET=earth
+# DST_PREFIX=earth_ndefl
+# DST_FORMAT=ns
+# DST_SCALE=0.04
+# DST_OFFSET=-50
+# DST_CPT=@earth_defl.cpt
+# DST_SRTM=no
+#
+# List of desired output resolution and chunk size.  Flag the source resolution with code == master
+# res	unit	tile	chunk	code
+01		m		30		4096	master
+02		m		60		4096
+03		m		90		2048
+04		m		180		2048
+05		m		180		1024
+06		m		0		4096
+10		m		0		4096
+15		m		0		4096
+20		m		0		4096
+30		m		0		4096
+01		d		0		4096


### PR DESCRIPTION
THe deflection of the vertical is a standard geodetic measure, and having the gravity errors in the faa (due to oceanography and ice) is useful too. Asked David about desired CPTs but we may need to invent some.