### PR TITLE
WIP Fixing missing nodes in mss

### DIFF
--- a/recipes/earth_mss.recipe
+++ b/recipes/earth_mss.recipe
@@ -7,16 +7,17 @@
 # To be given as input file to script srv_downsampler_grid.sh
 #
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
-#	name of z-variable, and z unit.
+#	name of z-variable, z unit, and opetional special tasks (SRC_RENAME, SRC_PROCESS, SRC_EXPAND, SRC_CUSTUM).
 # SRC_FILE=https://topex.ucsd.edu/pub/MSS_CNES_CLS22/CNES_CLS_22_H.nc
+# SRC_RENAME=CNES_CLS_22_H.grd
 # SRC_TITLE=CNES_CLS_2022_Mean_Sea_Surface
 # SRC_REF="Schaeffer_et_al.,_2023"
 # SRC_DOI="https://doi.org/10.3390/rs15112910"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=mss
 # SRC_UNIT=m
-# SRC_PROCESS="if [ ! -f CNES_CLS_22_H_orig.nc ]; then cp -f CNES_CLS_22_H.nc CNES_CLS_22_H_orig.nc; fi"
-# SRC_CUSTOM="gmt grdcut CNES_CLS_22_H_orig.nc -Rd -N -GCNES_CLS_22_H.nc"
+# SRC_EXT=grd
+# SRC_EXPAND="gmt grdcut CNES_CLS_22_H.grd -Rd -N -GCNES_CLS_22_H_ext.nc; mv -f CNES_CLS_22_H_ext.nc CNES_CLS_22_H.grd"
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
 # DST_NODES=g,p

--- a/recipes/earth_mss.recipe
+++ b/recipes/earth_mss.recipe
@@ -15,7 +15,7 @@
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=mss
 # SRC_UNIT=m
-# SRC_PROCESS="if [ ! -f CNES_CLS_22_H_orig.nc]; then cp -f CNES_CLS_22_H.nc CNES_CLS_22_H_orig.nc; fi"
+# SRC_PROCESS="if [ ! -f CNES_CLS_22_H_orig.nc ]; then cp -f CNES_CLS_22_H.nc CNES_CLS_22_H_orig.nc; fi"
 # SRC_CUSTOM="gmt grdcut CNES_CLS_22_H_orig.nc -Rd -N -GCNES_CLS_22_H.nc"
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian

--- a/recipes/earth_mss.recipe
+++ b/recipes/earth_mss.recipe
@@ -15,7 +15,8 @@
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=mss
 # SRC_UNIT=m
-#
+# SRC_PROCESS="if [ ! -f CNES_CLS_22_H_orig.nc]; then cp -f CNES_CLS_22_H.nc CNES_CLS_22_H_orig.nc; fi"
+# SRC_CUSTOM="gmt grdcut CNES_CLS_22_H_orig.nc -Rd -N -GCNES_CLS_22_H.nc"
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
 # DST_NODES=g,p


### PR DESCRIPTION
Here is a first cut.  Suggest you use this recipe, add a temporary exit in srv_downsamples_grid.c around line 142 and run it as

bash -xv scripts/srv_downsamples_grid.c  earth_mss

amd examine output.  The idea here is that (unfortunately) they called it *.nc so we are stuck with what SRC_CUSTOM and SRC_PROCESS allow. We want

make an *orig* copy if none exists in staging (this will happen once) RUn the custom command that reads the orig file and expands to -Rd with NaNs

The rest of the scripts should then handle things.  WIP since I have not tested it yet and likely needs some changes.