### PR TITLE
Script to count files on a server or your staging area

### DIFF
--- a/recipes/earth_faaerror.recipe
+++ b/recipes/earth_faaerror.recipe
@@ -17,6 +17,7 @@
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=faaerror
 # SRC_UNIT=mGal
+# SRC_RUN="gmt grdmath grav_error_32.1.nc DUP 0 GT 0 NAN MUL = grav_error_32.1.nc"
 #
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian

--- a/recipes/earth_mss.recipe
+++ b/recipes/earth_mss.recipe
@@ -17,7 +17,7 @@
 # SRC_NAME=mss
 # SRC_UNIT=m
 # SRC_EXT=grd
-# SRC_EXPAND="gmt grdcut CNES_CLS_22_H.grd -Rd -N -GCNES_CLS_22_H_ext.nc; mv -f CNES_CLS_22_H_ext.nc CNES_CLS_22_H.grd"
+# SRC_RUN="gmt grdcut CNES_CLS_22_H.grd -Rd -N -GCNES_CLS_22_H_ext.nc; mv -f CNES_CLS_22_H_ext.nc CNES_CLS_22_H.grd"
 # Destination: Specify output node registration, file prefix, and netCDF format
 # DST_MODE=Cartesian
 # DST_NODES=g,p

--- a/scripts/srv_downsampler_grid.sh
+++ b/scripts/srv_downsampler_grid.sh
@@ -82,7 +82,7 @@ grep SRC_RADIUS $RECIPE  | awk '{print $2}' >> ${TMP}/par.sh
 grep SRC_NAME $RECIPE    | awk '{print $2}' >> ${TMP}/par.sh
 grep SRC_UNIT $RECIPE    | awk '{print $2}' >> ${TMP}/par.sh
 grep SRC_PROCESS $RECIPE | awk -F'#' '{print $2}' >> ${TMP}/par.sh
-grep SRC_EXPAND $RECIPE  | awk -F'#' '{print $2}' >> ${TMP}/par.sh
+grep SRC_RUN $RECIPE  | awk -F'#' '{print $2}' >> ${TMP}/par.sh
 grep SRC_CUSTOM $RECIPE  | awk -F'#' '{print $2}' >> ${TMP}/par.sh
 grep SRC_EXT $RECIPE     | awk '{print $2}' >> ${TMP}/par.sh
 grep DST_MODE $RECIPE    | awk '{print $2}' >> ${TMP}/par.sh
@@ -126,9 +126,9 @@ if [ ! "X${SRC_PROCESS}" = "X" ]; then	# Pre-processing data to get initial grid
 	SRC_FILE=$(basename ${SRC_FILE} zip)"${SRC_EXT}"
 fi
 # 5.3 See if we must fill the grid to -Rd
-if [ ! "X${SRC_EXPAND}" = "X" ]; then	# Specified commands only
+if [ ! "X${SRC_RUN}" = "X" ]; then	# Specified commands only
 	# Just execute this command
-	$(echo ${SRC_EXPAND} | tr '";' ' \n' > ${TMP}/job2.sh)
+	$(echo ${SRC_RUN} | tr '";' ' \n' > ${TMP}/job2.sh)
 	bash ${TMP}/job2.sh
 fi
 # 5.3 See if given any custom formatting steps

--- a/scripts/srv_staging_vs_candidate.sh
+++ b/scripts/srv_staging_vs_candidate.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This checks if all the files in the given directory
+# made it to the candidate server. Compare what you get
+# by running this script one the candidate server and your staging dir
+
+if [ $# -eq 0 ]; then
+	cat <<- EOF >&2
+	usage: srv_staging_vs_candidate.sh <dir>
+		<dir> is the top server directory with planets and earth within it
+	EOF
+	exit -1
+fi
+
+DIR=$1
+
+rm -f ${HOME}/dataset.log
+
+# 1. Move into the dir with the planets
+cd ${DIR}
+find . -name '*_*_server.txt' | grep -v gmt_data_server.txt | awk -F/ '{print $3}' > /tmp/datasets.lis
+while read dataset; do
+	planet=$(echo $dataset | awk -F_ '{print $1}')
+	find ${planet}/${dataset} -name '*.jp2' >> ${HOME}/dataset.log
+	find ${planet}/${dataset} -name '*.grd' >> ${HOME}/dataset.log
+	find ${planet}/${dataset} -name '*.tif' >> ${HOME}/dataset.log
+done < /tmp/datasets.lis
+n_datasets=$(wc -l /tmp/datasets.lis | awk '{printf "%d\n", $1}')
+n_files=$(wc -l ${HOME}/dataset.log | awk '{printf "%d\n", $1}')
+echo "Found a total of ${n_files} files for ${n_datasets} data sets"
+echo "Log file is ${HOME}/dataset.log"


### PR DESCRIPTION
Run `scripts/srv_staging_vs_candidate.sh staging` to get a total count of the number of files under that dir, and run the same script with the path to the relevant server dir on the gmtserver.  if the counts differ then probably the scp job timed up due to excessive Internet traffic!  I get (with staging dir full):

```
scripts/srv_staging_vs_candidate.sh staging
Found a total of 12740 files for 23 data sets
Log file is /Users/pwessel/dataset.log

```
while on the server I get [not update yet of course]

```
/export/gmtserver/gmt/gmtserver-admin/srv_staging_vs_candidate.sh server            
Found a total of 12250 files for 23 data sets
Log file is /export/gmtserver/pwessel/dataset.log
```

running` place-earth-gebo` now.