### PR TITLE
Fix place_candidate.sh

### DIFF
--- a/scripts/place_candidate.sh
+++ b/scripts/place_candidate.sh
@@ -66,6 +66,6 @@ if [ $answer = "Y" ] || [ "${answer}" == "y" ]; then
 	echo "Copying over the new ${planet}/${dataset} from staging to the ${CANDIDATE} server"
 	scp -r staging/${planet}/${dataset} "${the_user}@${CANDIDATE_SERVER}/${planet}/"
 	echo "Setting permissions on ${planet}/${dataset}"
-	ssh ${the_user}@${CANDIDATE}.generic-mapping-tools.org "chmod -R g+rw,o+r ${CANDIDATE_DIR}/${planet}"
+	ssh ${the_user}@${CANDIDATE}.generic-mapping-tools.org "chmod -R g+rw,o+r ${CANDIDATE_DIR}/${planet}/${dataset}"
 	echo "Refreshing of ${planet}/${dataset} completed"
 fi


### PR DESCRIPTION
I think that `${dataset}` was missing on line 69. This line is used to set permissions (`chmod`). I am not sure if the proposed modification is correct. But I think it makes sense seeing the message of the previous line. 

BTW, when I ran the script as is, it failed me with the earth_vgg and earth_synbath grids (and I don't know if any others). I think at the time Paul didn't change the permissions on those datasets. Maybe in the future we will have a problem when it is necessary to update them. 

The modified script worked when I tried to run make place-earth-wdmam (#245). The original script failed me for the reasons mentioned in the previous paragraph.