### PR TITLE
Upgrate Earth gravimetric recipes for SWOT data

### DIFF
--- a/recipes/earth_edefl.recipe
+++ b/recipes/earth_edefl.recipe
@@ -1,10 +1,10 @@
 # Recipe file for down-filtering Sandwell east deflection grid with EGM2008 on land
 # 2025-04-15 FE
 #
-# We use a precision of 0.03125 microradians
+# We use a precision of 0.015625 microradians
 # This is based on the raw data file for version 3.
-# The range of -406.305541992 to +427.036224365 microradians means we may use offset of -10 and scale of 0.03125
-# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.03125 = 1/32)
+# The range of -406.305541992 to +427.036224365 microradians means we may use offset of -10 and scale of 0.015625
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.015625 = 1/64)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #
@@ -24,7 +24,7 @@
 # DST_PLANET=earth
 # DST_PREFIX=earth_edefl
 # DST_FORMAT=ns
-# DST_SCALE=0.04
+# DST_SCALE=0.015625
 # DST_OFFSET=-10
 # DST_CPT=@earth_defl.cpt
 # DST_SRTM=no

--- a/recipes/earth_edefl.recipe
+++ b/recipes/earth_edefl.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering Sandwell east deflection grid with EGM2008 on land
-# 2025-04-15 FE
+# 2025-04-16 FE
 #
 # We use a precision of 0.015625 microradians
 # This is based on the raw data file for version 3.

--- a/recipes/earth_edefl.recipe
+++ b/recipes/earth_edefl.recipe
@@ -1,8 +1,8 @@
 # Recipe file for down-filtering Sandwell east deflection grid with EGM2008 on land
-# 2023-09-21 PW
+# 2025-04-15 FE
 #
 # We use a precision of 0.03125 microradians
-# This is based on the raw data file for version 32.
+# This is based on the raw data file for version 3.
 # The range of -406.305541992 to +427.036224365 microradians means we may use offset of -10 and scale of 0.03125
 # Scale is also chosen so that 1/scale is a finite-decimal number (here 0.03125 = 1/32)
 #
@@ -10,10 +10,10 @@
 #
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
-# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/east_32.1.nc
-# SRC_TITLE=IGPP_Earth_East_Deflection_of_the_Vertical_v32
-# SRC_REF="Sandwell_et_al.,_2019"
-# SRC_DOI="https://doi.org/10.1016/j.asr.2019.09.011"
+# SRC_FILE=https://topex.ucsd.edu/pub/global_grav_1min_SWOT/east_SWOT_03.nc
+# SRC_TITLE=IGPP_Earth_SWOT_East_Deflection_of_the_Vertical_v3
+# SRC_REF="Yu_et_al.,_2024"
+# SRC_DOI="https://doi.org/10.1126/science.ads4472"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=edefl
 # SRC_UNIT=microradians

--- a/recipes/earth_faa.recipe
+++ b/recipes/earth_faa.recipe
@@ -1,10 +1,10 @@
 # Recipe file for down-filtering Sandwell SWOT gravity grid with EGM2008 on land
 # 2025-04-15 FE
 #
-# We use a precision of 0.0625 mGal
+# We use a precision of 0.03125 mGal
 # This is based on the raw data file for version 3.
-# The range of -712.481506348 to +942.2193604 mGal means we may use offset of 300 and scale of 0.0625
-# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.0625 = 1/16)
+# The range of -712.481506348 to +942.2193604 mGal means we may use offset of 0 and scale of 0.03125
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.03125 = 1/32)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #
@@ -24,8 +24,8 @@
 # DST_PLANET=earth
 # DST_PREFIX=earth_faa
 # DST_FORMAT=ns
-# DST_SCALE=0.0625
-# DST_OFFSET=300
+# DST_SCALE=0.03125
+# DST_OFFSET=0
 # DST_CPT=@earth_faa.cpt
 # DST_SRTM=no
 #

--- a/recipes/earth_faa.recipe
+++ b/recipes/earth_faa.recipe
@@ -1,19 +1,19 @@
-# Recipe file for down-filtering Sandwell FAA gravity grid with EGM2008 on land
-# 2022-08-19 FE
+# Recipe file for down-filtering Sandwell SWOT gravity grid with EGM2008 on land
+# 2025-04-15 FE
 #
-# We use a precision of 0.025 mGal
-# This is based on the raw data file for version 32.
-# The range of -388.633911133 to +941.817321777 mGal means we may use offset of 300 and scale of 0.025
-# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.025 = 1/40)
+# We use a precision of 0.0625 mGal
+# This is based on the raw data file for version 3.
+# The range of -712.481506348 to +942.2193604 mGal means we may use offset of 300 and scale of 0.0625
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.0625 = 1/16)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
-# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/grav_32.1.nc
-# SRC_TITLE=IGPP_Earth_Free_Air_Gravity_Anomalies_v32
-# SRC_REF="Sandwell_et_al.,_2019"
-# SRC_DOI="https://doi.org/10.1016/j.asr.2019.09.011"
+# SRC_FILE=https://topex.ucsd.edu/pub/global_grav_1min_SWOT/grav_SWOT_03.nc
+# SRC_TITLE=IGPP_Earth_SWOT_Free_Air_Gravity_Anomalies_v3
+# SRC_REF="Yu_et_al.,_2024"
+# SRC_DOI="https://doi.org/10.1126/science.ads4472"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=faa
 # SRC_UNIT=mGal
@@ -24,7 +24,7 @@
 # DST_PLANET=earth
 # DST_PREFIX=earth_faa
 # DST_FORMAT=ns
-# DST_SCALE=0.025
+# DST_SCALE=0.0625
 # DST_OFFSET=300
 # DST_CPT=@earth_faa.cpt
 # DST_SRTM=no

--- a/recipes/earth_faa.recipe
+++ b/recipes/earth_faa.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering Sandwell SWOT gravity grid with EGM2008 on land
-# 2025-04-15 FE
+# 2025-04-16 FE
 #
 # We use a precision of 0.03125 mGal
 # This is based on the raw data file for version 3.

--- a/recipes/earth_ndefl.recipe
+++ b/recipes/earth_ndefl.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering Sandwell north deflection grid with EGM2008 on land
-# 2023-09-21 PW
+# 2025-04-16 FE
 #
 # We use a precision of 0.02 microradians
 # This is based on the raw data file for version 3.

--- a/recipes/earth_ndefl.recipe
+++ b/recipes/earth_ndefl.recipe
@@ -2,18 +2,18 @@
 # 2023-09-21 PW
 #
 # We use a precision of 0.03125 microradians
-# This is based on the raw data file for version 32.
-# The range of -570.314331055 to +484.914001465 microradians means we may use offset of -50 and scale of 0.04
+# This is based on the raw data file for version 3.
+# The range of -725.712219238 to +484.914001465 microradians means we may use offset of -50 and scale of 0.04
 # Scale is also chosen so that 1/scale is a finite-decimal number (here 0.04 = 1/25)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
-# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/north_32.1.nc
-# SRC_TITLE=IGPP_Earth_North_Deflection_of_the_Vertical_v32
-# SRC_REF="Sandwell_et_al.,_2019"
-# SRC_DOI="https://doi.org/10.1016/j.asr.2019.09.011"
+# SRC_FILE=https://topex.ucsd.edu/pub/global_grav_1min_SWOT/north_SWOT_03.nc
+# SRC_TITLE=IGPP_Earth_SWOT_North_Deflection_of_the_Vertical_v3
+# SRC_REF="Yu_et_al.,_2024"
+# SRC_DOI="https://doi.org/10.1126/science.ads4472"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=ndefl
 # SRC_UNIT=microradians

--- a/recipes/earth_ndefl.recipe
+++ b/recipes/earth_ndefl.recipe
@@ -1,10 +1,10 @@
 # Recipe file for down-filtering Sandwell north deflection grid with EGM2008 on land
 # 2023-09-21 PW
 #
-# We use a precision of 0.03125 microradians
+# We use a precision of 0.02 microradians
 # This is based on the raw data file for version 3.
-# The range of -725.712219238 to +484.914001465 microradians means we may use offset of -50 and scale of 0.04
-# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.04 = 1/25)
+# The range of -725.712219238 to +484.914001465 microradians means we may use offset of -100 and scale of 0.02
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.02 = 1/50)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #
@@ -24,8 +24,8 @@
 # DST_PLANET=earth
 # DST_PREFIX=earth_ndefl
 # DST_FORMAT=ns
-# DST_SCALE=0.04
-# DST_OFFSET=-50
+# DST_SCALE=0.02
+# DST_OFFSET=-100
 # DST_CPT=@earth_defl.cpt
 # DST_SRTM=no
 #

--- a/recipes/earth_vgg.recipe
+++ b/recipes/earth_vgg.recipe
@@ -1,10 +1,10 @@
 # Recipe file for down-filtering Sandwell VGG grid with EGM2008 on land
 # 2025-04-15 FE
 #
-# We use a precision of 0.03125 Eotvos
+# We use a precision of 0.0625 Eotvos
 # This is based on the raw data file for version 3.
-# The range of -2311.2019043 to +1326.34387207 Eotvos means we may use offset of 100 and scale of 0.03125
-# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.03125 = 1/32)
+# The range of -2311.2019043 to +1326.34387207 Eotvos means we may use offset of -300 and scale of 0.0625
+# Scale is also chosen so that 1/scale is a finite-decimal number (here 0.0625 = 1/16)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #
@@ -24,8 +24,8 @@
 # DST_PLANET=earth
 # DST_PREFIX=earth_vgg
 # DST_FORMAT=ns
-# DST_SCALE=0.03125
-# DST_OFFSET=100
+# DST_SCALE=0.0625
+# DST_OFFSET=-300
 # DST_CPT=@earth_vgg.cpt
 # DST_SRTM=no
 #

--- a/recipes/earth_vgg.recipe
+++ b/recipes/earth_vgg.recipe
@@ -1,5 +1,5 @@
 # Recipe file for down-filtering Sandwell VGG grid with EGM2008 on land
-# 2025-04-15 FE
+# 2025-04-16 FE
 #
 # We use a precision of 0.0625 Eotvos
 # This is based on the raw data file for version 3.

--- a/recipes/earth_vgg.recipe
+++ b/recipes/earth_vgg.recipe
@@ -1,19 +1,19 @@
 # Recipe file for down-filtering Sandwell VGG grid with EGM2008 on land
-# 2022-08-19 FE
+# 2025-04-15 FE
 #
 # We use a precision of 0.03125 Eotvos
-# This is based on the raw data file for version 32.
-# The range of -806.440856934 to +1070.05725098 Eotvos means we may use offset of 100 and scale of 0.03125
+# This is based on the raw data file for version 3.
+# The range of -2311.2019043 to +1326.34387207 Eotvos means we may use offset of 100 and scale of 0.03125
 # Scale is also chosen so that 1/scale is a finite-decimal number (here 0.03125 = 1/32)
 #
 # To be given as input file to script srv_downsampler_grid.sh
 #
 # Source: Information about master file, a title name (with underscores for spaces), planetary radius (km),
 #	name of z-variable, and z unit.
-# SRC_FILE=ftp://topex.ucsd.edu/pub/global_grav_1min/curv_32.1.nc
-# SRC_TITLE=IGPP_Earth_Vertical_Gravity_Gradient_Anomalies_v32
-# SRC_REF="Sandwell_et_al.,_2019"
-# SRC_DOI="https://doi.org/10.1016/j.asr.2019.09.011"
+# SRC_FILE=https://topex.ucsd.edu/pub/global_grav_1min_SWOT/curv_SWOT_03.nc
+# SRC_TITLE=IGPP_Earth_SWOT_Vertical_Gravity_Gradient_Anomalies_v3
+# SRC_REF="Yu_et_al.,_2024"
+# SRC_DOI="https://doi.org/10.1126/science.ads4472"
 # SRC_RADIUS=6371.0087714
 # SRC_NAME=vgg
 # SRC_UNIT=Eotvos


### PR DESCRIPTION
This PR is only to upgrade the recipes to use the SWOT grids (in this link https://topex.ucsd.edu/pub/global_grav_1min_SWOT/) instead of this ones (https://topex.ucsd.edu/pub/global_grav_1min/). 

In the four recipes I change the precision (or scale) and offset. I also change the SRC_FILE, REF and DOI. 

I think that only important thing that I want your approval is for the SRC_TITLE of each recipe.

See discussion on #271 