### PR TITLE
Remove the South Africa mirror from the "Check Mirrors" workflow

### DIFF
--- a/.github/workflows/check-mirrors.yml
+++ b/.github/workflows/check-mirrors.yml
@@ -32,7 +32,6 @@ jobs:
             "noaa",
             "portugal",
             "singapore",
-            "south-africa",
         ]
 
         error = 0


### PR DESCRIPTION
As mentioned in https://github.com/GenericMappingTools/website/pull/162, the South Africa mirror is no longer available.