### PR TITLE
Delete cache/qbezier_test.def

### DIFF
--- a/cache/qbezier_test.def
+++ b/cache/qbezier_test.def
@@ -1,6 +1,0 @@
-# Test quadratic Bezier Q command
-# Draws a simple parabolic arc from (-0.5,0) to (0.5,0) curving up to (0,0.5)
-# M = moveto start, Q = quadratic bezier, S = stroke
--0.5  0.0  M
- 0.0  0.5  0.5  0.0  Q
-S


### PR DESCRIPTION
No longer used after https://github.com/GenericMappingTools/gmt/pull/9060.